### PR TITLE
Vectorize Fext

### DIFF
--- a/Functions/Assembly/getStrain.m
+++ b/Functions/Assembly/getStrain.m
@@ -192,7 +192,7 @@ else
                     % convert B matrix to Voigt form
                     Bv = getBv(B', Mesh.nsd);
 
-                    D = getD(Material.E(Xi), Material.nu(Xi), Mesh.nsd, Material.Dtype);    
+                    D = getD(Material.E(Xi'), Material.nu(Xi'), Mesh.nsd, Material.Dtype);    
 
                     % calculate stress and strain at quadrature point
                     strain_q = Bv'*de;


### PR DESCRIPTION
## What?
Temporary change to how tractions are assembled into the global force vector. Currently, tractions have to be pre-integrated in the config file and attributed to their nodes, so we can just directly apply the integrated point loads into the force vector.

## Why?
Previously used a for-loop that performed unnecessary iterations. Caused significant computational expense in fine meshes.

## How?
Previously used a for-loop that looped through all elements and nodes to see if the traction node was part of the element, now we just directly assemble the forces.

## Testing?
RunSim MasterConfig at high element counts, RunTests
Change reduces Fext computational time from 38s to 1.4s at 3e5 dofs.

## Anything Else?
Temporary implementation to improve efficiency while we work towards edge element integration of tractions.