### PR TITLE
Q8 reduced

### DIFF
--- a/Config Files/MasterConfigFile.m
+++ b/Config Files/MasterConfigFile.m
@@ -138,8 +138,11 @@ function [Mesh, Material, BC, Control] = MasterConfigFile(config_dir, progress_o
             meshFileName = 'Unstructured_sample.msh';
             % number of space dimensions 
             nsd = 2;
+            % Optional 5th input in case Q8 with reduced integration is desired
+            Q8_reduced = 'Q8'; %Do not consider this input if a case different than Q8 with reduced integration is desired
             
             Mesh = BuildMesh_GMSH(meshFileName, nsd, config_dir, progress_on);            
+%             Mesh = BuildMesh_GMSH(meshFileName, nsd, config_dir, progress_on,Q8_reduced);            
     end    
     
 %% Material Properties (Solid)

--- a/Functions/Mesh Generation/BuildMesh_GMSH.m
+++ b/Functions/Mesh Generation/BuildMesh_GMSH.m
@@ -99,7 +99,12 @@ function Mesh = BuildMesh_GMSH(meshFileName, nsd, config_dir, progress_on)
         case 9
             Mesh.type = 'Q9';
         case 8
-            Mesh.type = 'B8';
+            switch nsd
+                case 2 % 2D → Q8 with reduced integration
+                    Mesh.type = 'Q8';
+                case 3 % 3D
+                    Mesh.type = 'B8';
+            end
     end
             
 %% Nodal DOFs

--- a/Functions/Post-processing/WriteMesh2VTK.m
+++ b/Functions/Post-processing/WriteMesh2VTK.m
@@ -147,6 +147,10 @@ else
      
         conn = [nne*ones(ne,1),conn-ones(ne,nne) ];
         cell_type = 23;   
+    elseif nsd == 2 && nne == 8 %Q8
+        conn = [nne*ones(ne,1),conn-ones(ne,nne)];
+        outputformat = '%d %d %d %d %d %d %d %d %d \n';
+        cell_type = 23;
     elseif nsd == 3 && nne == 8 %B8
         conn = [nne*ones(ne,1),conn-ones(ne,nne)];
         outputformat = '%d %d %d %d %d %d %d %d %d \n';

--- a/Functions/Post-processing/WriteMesh2VTK.m
+++ b/Functions/Post-processing/WriteMesh2VTK.m
@@ -147,7 +147,7 @@ else
      
         conn = [nne*ones(ne,1),conn-ones(ne,nne) ];
         cell_type = 23;   
-    elseif nsd == 2 && nne == 8 %B8
+    elseif nsd == 3 && nne == 8 %B8
         conn = [nne*ones(ne,1),conn-ones(ne,nne)];
         outputformat = '%d %d %d %d %d %d %d %d %d \n';
         cell_type = 12;

--- a/Functions/Shape Functions and Quadrature/GlobalQuad.m
+++ b/Functions/Shape Functions and Quadrature/GlobalQuad.m
@@ -42,7 +42,7 @@ switch elem_type
         [Quad.W, Quad.Q] = quadrature(qo, 'TRIANGULAR', nsd);
     case 'Q8'
         % For Q8 with reduced integration 
-        [Quad.W, Quad.Q] = quadrature(4, 'GAUSS', nsd);
+        [Quad.W, Quad.Q] = quadrature(2, 'GAUSS', nsd);
     otherwise
         [Quad.W, Quad.Q] = quadrature(qo, 'GAUSS', nsd);
 end

--- a/Functions/Shape Functions and Quadrature/GlobalQuad.m
+++ b/Functions/Shape Functions and Quadrature/GlobalQuad.m
@@ -14,7 +14,7 @@ function Quad = GlobalQuad(nsd, elem_type, qo)
 %           	triangle is T3 a four node quadralateral is Q4 a 4 node 
 %           	tetrahedra is H4 a 27 node brick is B27 etc. Presently 
 %           	defined are L2, L3, L4, T3, T4(cubic bubble), T6, Q4, 
-% 				Q9, H4, H10, B8 and B27.  
+% 				Q8 (reduced integration), Q9, H4, H10, B8 and B27.  
 %   qo:  		quadrature order
 % 
 %   --------------------------------------------------------------------
@@ -40,6 +40,9 @@ switch elem_type
         [Quad.W, Quad.Q] = quadrature(qo, 'TRIANGULAR', nsd);
     case 'T6'
         [Quad.W, Quad.Q] = quadrature(qo, 'TRIANGULAR', nsd);
+    case 'Q8'
+        % For Q8 with reduced integration 
+        [Quad.W, Quad.Q] = quadrature(4, 'GAUSS', nsd);
     otherwise
         [Quad.W, Quad.Q] = quadrature(qo, 'GAUSS', nsd);
 end

--- a/Functions/Shape Functions and Quadrature/getXI.m
+++ b/Functions/Shape Functions and Quadrature/getXI.m
@@ -72,6 +72,24 @@ switch type
         elseif node_num == 4
             xi_node = [-1 1];
         end
+    case 'Q8'
+        if node_num == 1
+            xi_node = [-1 -1];
+        elseif node_num == 2
+            xi_node = [1 -1];
+        elseif node_num == 3
+            xi_node = [1 1];
+        elseif node_num == 4
+            xi_node = [-1 1];
+        elseif node_num == 5
+            xi_node = [0 -1];
+        elseif node_num == 6
+            xi_node = [1 0];
+        elseif node_num == 7
+            xi_node = [0 1];
+        elseif node_num == 8
+            xi_node = [-1 0];
+        end
     case 'Q9'
         if node_num == 1
             xi_node = [-1 -1];

--- a/Functions/Shape Functions and Quadrature/lagrange_basis.m
+++ b/Functions/Shape Functions and Quadrature/lagrange_basis.m
@@ -54,6 +54,7 @@ function [N, dNdxi, Nv] = lagrange_basis(type, coord, dim)
 %   [4] Belytschko, T., Liu, W. K., Moran, B., & Elkhodary, K. (2014). 
 %       Nonlinear Finite Elements for Continua and Structures. John Wiley &
 %       Sons.
+%   [5] J. N. Reddy  (2006). AN Introduction to the Finite Element Meethod.
 
 % Acknowledgements: Jack Chessa
 
@@ -239,6 +240,72 @@ switch type
                         1+eta,      1+xi;
                         -(1+eta),   1-xi];
         end
+        
+    case 'Q8'
+    %%%%%%%%%%%% Q8 NINE NODE QUADRILATERIAL ELEMENT %%%%%%%%%%%%%
+    %
+    %    4---------7----------3
+    %    |                    |
+    %    |                    |
+    %    |                    |
+    %    |                    |
+    %    8                    6
+    %    |                    |
+    %    |                    |
+    %    |                    |
+    %    |                    |
+    %    1----------5---------2   
+        if size(coord,2) < 2
+            error('Error: two coordinates needed for the Q8 element')
+        else
+            xi = coord(1); 
+            eta = coord(2);
+            % In this case, nodes are numbered as in % Ref. [5] pg. 537 
+            % Ref [5] → sketch
+            % 1 → 1
+            % 2 → 5
+            % 3 → 2
+            % 4 → 8
+            % 5 → 6
+            % 6 → 4
+            % 7 → 7
+            % 8 → 3
+%             N = [-1/4*(1 - xi)*(1 - eta)*(1 + xi - eta);        
+%                     1/2*(-xi^2 + 1)*(1 - eta);         
+%                     1/4*(1 + xi)*(1 - eta)*(-1 + xi - eta);
+%                     1/2*(1 - xi)*(-eta^2 + 1);
+%                     1/2*(1 + xi)*(-eta^2 + 1);
+%                     1/4*(1 - xi)*(1 + eta)*(-1 - xi + eta);
+%                     1/2*(-xi^2 + 1)*(1 + eta);
+%                     1/4*(1 + xi)*(1 + eta)*(-1 + xi + eta)];
+%             dNdxi = [((1 - eta)*(1 + xi - eta))/4 - (1/4 - xi/4)*(1 - eta), (1/4 - xi/4)*(1 + xi - eta) + (1/4 - xi/4)*(1 - eta);        
+%                     -xi*(1 - eta), xi^2/2 - 1/2;  
+%                     ((1 - eta)*(-1 + xi - eta))/4 + ((1 + xi)*(1 - eta))/4, -((1 + xi)*(-1 + xi - eta))/4 - ((1 + xi)*(1 - eta))/4 ;  
+%                     eta^2/2 - 1/2, -(1 - xi)*eta;  
+%                     -eta^2/2 + 1/2, -(1 + xi)*eta ;  
+%                     -((1 + eta)*(-1 - xi + eta))/4 - ((1 - xi)*(1 + eta))/4, ((1 - xi)*(-1 - xi + eta))/4 + ((1 - xi)*(1 + eta))/4;  
+%                     -xi*(1 + eta), -xi^2/2 + 1/2;  
+%                     ((1 + eta)*(-1 + xi + eta))/4 + ((1 + xi)*(1 + eta))/4,  ((1 + xi)*(-1 + xi + eta))/4 + ((1 + xi)*(1 + eta))/4 ];
+            % In this case, nodes are numbered as in the sketch 
+            
+            N = [-1/4*(1 - xi)*(1 - eta)*(1 + xi - eta); 
+                    1/4*(1 + xi)*(1 - eta)*(-1 + xi - eta);
+                    1/4*(1 + xi)*(1 + eta)*(-1 + xi + eta);
+                    1/4*(1 - xi)*(1 + eta)*(-1 - xi + eta);
+                    1/2*(-xi^2 + 1)*(1 - eta);         
+                    1/2*(1 + xi)*(-eta^2 + 1);
+                    1/2*(-xi^2 + 1)*(1 + eta);
+                    1/2*(1 - xi)*(-eta^2 + 1)];
+            dNdxi = [((1 - eta)*(1 + xi - eta))/4 - (1/4 - xi/4)*(1 - eta), (1/4 - xi/4)*(1 + xi - eta) + (1/4 - xi/4)*(1 - eta);        
+                    ((1 - eta)*(-1 + xi - eta))/4 + ((1 + xi)*(1 - eta))/4, -((1 + xi)*(-1 + xi - eta))/4 - ((1 + xi)*(1 - eta))/4 ;  
+                    ((1 + eta)*(-1 + xi + eta))/4 + ((1 + xi)*(1 + eta))/4,  ((1 + xi)*(-1 + xi + eta))/4 + ((1 + xi)*(1 + eta))/4;
+                    -((1 + eta)*(-1 - xi + eta))/4 - ((1 - xi)*(1 + eta))/4, ((1 - xi)*(-1 - xi + eta))/4 + ((1 - xi)*(1 + eta))/4;
+                    -xi*(1 - eta), xi^2/2 - 1/2;  
+                    -eta^2/2 + 1/2, -(1 + xi)*eta ;
+                    -xi*(1 + eta), -xi^2/2 + 1/2;
+                    eta^2/2 - 1/2, -(1 - xi)*eta];      
+        end
+    
 
     case 'Q9'
     %%%%%%%%%%%% Q9 NINE NODE QUADRILATERIAL ELEMENT %%%%%%%%%%%%%

--- a/Functions/Shape Functions and Quadrature/lagrange_basis.m
+++ b/Functions/Shape Functions and Quadrature/lagrange_basis.m
@@ -242,7 +242,7 @@ switch type
         end
         
     case 'Q8'
-    %%%%%%%%%%%% Q8 NINE NODE QUADRILATERIAL ELEMENT %%%%%%%%%%%%%
+    %%%%%%%%%%%% Q8 EIGHT NODE QUADRILATERIAL ELEMENT %%%%%%%%%%%%%
     %
     %    4---------7----------3
     %    |                    |
@@ -270,7 +270,7 @@ switch type
             % 6 → 4
             % 7 → 7
             % 8 → 3
-%             N = [-1/4*(1 - xi)*(1 - eta)*(1 + xi - eta);        
+%             N = [-1/4*(1 - xi)*(1 - eta)*(1 + xi + eta);        
 %                     1/2*(-xi^2 + 1)*(1 - eta);         
 %                     1/4*(1 + xi)*(1 - eta)*(-1 + xi - eta);
 %                     1/2*(1 - xi)*(-eta^2 + 1);
@@ -278,7 +278,7 @@ switch type
 %                     1/4*(1 - xi)*(1 + eta)*(-1 - xi + eta);
 %                     1/2*(-xi^2 + 1)*(1 + eta);
 %                     1/4*(1 + xi)*(1 + eta)*(-1 + xi + eta)];
-%             dNdxi = [((1 - eta)*(1 + xi - eta))/4 - (1/4 - xi/4)*(1 - eta), (1/4 - xi/4)*(1 + xi - eta) + (1/4 - xi/4)*(1 - eta);        
+%             dNdxi = [((1 - eta)*(1 + xi + eta))/4 - (1/4 - xi/4)*(1 - eta), (1/4 - xi/4)*(1 + xi + eta) - (1/4 - xi/4)*(1 - eta);        
 %                     -xi*(1 - eta), xi^2/2 - 1/2;  
 %                     ((1 - eta)*(-1 + xi - eta))/4 + ((1 + xi)*(1 - eta))/4, -((1 + xi)*(-1 + xi - eta))/4 - ((1 + xi)*(1 - eta))/4 ;  
 %                     eta^2/2 - 1/2, -(1 - xi)*eta;  
@@ -288,7 +288,7 @@ switch type
 %                     ((1 + eta)*(-1 + xi + eta))/4 + ((1 + xi)*(1 + eta))/4,  ((1 + xi)*(-1 + xi + eta))/4 + ((1 + xi)*(1 + eta))/4 ];
             % In this case, nodes are numbered as in the sketch 
             
-            N = [-1/4*(1 - xi)*(1 - eta)*(1 + xi - eta); 
+            N = [-1/4*(1 - xi)*(1 - eta)*(1 + xi + eta); 
                     1/4*(1 + xi)*(1 - eta)*(-1 + xi - eta);
                     1/4*(1 + xi)*(1 + eta)*(-1 + xi + eta);
                     1/4*(1 - xi)*(1 + eta)*(-1 - xi + eta);
@@ -296,7 +296,7 @@ switch type
                     1/2*(1 + xi)*(-eta^2 + 1);
                     1/2*(-xi^2 + 1)*(1 + eta);
                     1/2*(1 - xi)*(-eta^2 + 1)];
-            dNdxi = [((1 - eta)*(1 + xi - eta))/4 - (1/4 - xi/4)*(1 - eta), (1/4 - xi/4)*(1 + xi - eta) + (1/4 - xi/4)*(1 - eta);        
+            dNdxi = [((1 - eta)*(1 + xi + eta))/4 - (1/4 - xi/4)*(1 - eta), (1/4 - xi/4)*(1 + xi + eta) - (1/4 - xi/4)*(1 - eta);        
                     ((1 - eta)*(-1 + xi - eta))/4 + ((1 + xi)*(1 - eta))/4, -((1 + xi)*(-1 + xi - eta))/4 - ((1 + xi)*(1 - eta))/4 ;  
                     ((1 + eta)*(-1 + xi + eta))/4 + ((1 + xi)*(1 + eta))/4,  ((1 + xi)*(-1 + xi + eta))/4 + ((1 + xi)*(1 + eta))/4;
                     -((1 + eta)*(-1 - xi + eta))/4 - ((1 - xi)*(1 + eta))/4, ((1 - xi)*(-1 - xi + eta))/4 + ((1 - xi)*(1 + eta))/4;

--- a/RunTests.m
+++ b/RunTests.m
@@ -10,7 +10,7 @@
     % Test VTK output
     plot2vtk = 0;
 %     VTKFolder ='C:\Users\b3gee\Documents\Matlab Results\';
-    VTKFolder = 'C:\Users\knbetanc\OneDrive - University of Waterloo\Documents\UWaterloo\Research\GitHub\GCMLab-FEM';
+    VTKFolder = 'C:\Users\knbetanc\OneDrive - University of Waterloo\Documents\UWaterloo\Research\GitHub\Results';
     
     % suppress progress messages
     progress_on = 0;
@@ -28,7 +28,7 @@
     addpath(genpath(ConfigDir));
        
     % number of tests - Update when new tests added!
-    ntests = 22; 
+    ntests = 23; 
     
     nameslist = {};
     testnum = 0;
@@ -121,17 +121,21 @@
 %  acceptable
       run('Test Files/RunCantileverBeam')
 
-%% Test 20: Patch Test A - All nodal displacements prescribed Q9
+%% Test 20: Patch Test A - All nodal displacements prescribed Q8
 % Pass Condition: FEA solution displacements, stresses, and strains are exact
         run('Test Files/RunPatchTestAQ8')
 
-%% Test 21: Patch Test B - Dirichlet-Dirichlet BC Q9
+%% Test 21: Patch Test B - Dirichlet-Dirichlet BC Q8
 % Pass Condition: FEA solution displacements, stresses, and strains are exact
         run('Test Files/RunPatchTestBQ8')
 
-%% Test 22: Patch Test C - Dirichlet-Neumann BC Q9
+%% Test 22: Patch Test C - Dirichlet-Neumann BC Q8
 % Pass Condition: FEA solution displacements, stresses, and strains are exact
         run('Test Files/RunPatchTestCQ8')
+        
+%% Test 23: Manufactured Solution - Q8 element convergence
+% Pass Condition: FEA solution displacements, stresses, and strains are exact
+        run('Test Files/RunManSolQ8')
  
 % %% Test 8: Manufactured Solution - Q9 element convergence
 % %   Pass condition: L2-norm converges at a rate of at least h^3

--- a/RunTests.m
+++ b/RunTests.m
@@ -28,7 +28,7 @@
     addpath(genpath(ConfigDir));
        
     % number of tests - Update when new tests added!
-    ntests = 23; 
+    ntests = 24; 
     
     nameslist = {};
     testnum = 0;
@@ -137,6 +137,11 @@
 % Pass Condition: FEA solution displacements, stresses, and strains are exact
         run('Test Files/RunManSolQ8')
  
+%% Test 24: One Dimensional Problem
+%  Pass Condition: FEA solution displacements are exact
+      run('Test Files/RunTest1D')
+        
+
 % %% Test 8: Manufactured Solution - Q9 element convergence
 % %   Pass condition: L2-norm converges at a rate of at least h^3
 % %                    e-norm converges at a rate of at least h^2

--- a/RunTests.m
+++ b/RunTests.m
@@ -9,7 +9,9 @@
     
     % Test VTK output
     plot2vtk = 0;
-    VTKFolder ='C:\Users\b3gee\Documents\Matlab Results\';
+%     VTKFolder ='C:\Users\b3gee\Documents\Matlab Results\';
+    VTKFolder = 'C:\Users\knbetanc\OneDrive - University of Waterloo\Documents\UWaterloo\Research\GitHub\GCMLab-FEM';
+    
     % suppress progress messages
     progress_on = 0;
     
@@ -26,7 +28,7 @@
     addpath(genpath(ConfigDir));
        
     % number of tests - Update when new tests added!
-    ntests = 19; 
+    ntests = 22; 
     
     nameslist = {};
     testnum = 0;
@@ -118,7 +120,24 @@
 %  Pass Condition: Shear locking is prevented and error in displacement is
 %  acceptable
       run('Test Files/RunCantileverBeam')
-      
+
+%% Test 20: Patch Test A - All nodal displacements prescribed Q9
+% Pass Condition: FEA solution displacements, stresses, and strains are exact
+        run('Test Files/RunPatchTestAQ8')
+
+%% Test 21: Patch Test B - Dirichlet-Dirichlet BC Q9
+% Pass Condition: FEA solution displacements, stresses, and strains are exact
+        run('Test Files/RunPatchTestBQ8')
+
+%% Test 22: Patch Test C - Dirichlet-Neumann BC Q9
+% Pass Condition: FEA solution displacements, stresses, and strains are exact
+        run('Test Files/RunPatchTestCQ8')
+ 
+% %% Test 8: Manufactured Solution - Q9 element convergence
+% %   Pass condition: L2-norm converges at a rate of at least h^3
+% %                    e-norm converges at a rate of at least h^2
+%         run('Test Files/RunManSolQ9')
+
 %% Test X: [Test Name] - Short Test Description
 %   Pass Condtion:
 %       run('Test Files/RunTestX')

--- a/Test Files/Check Files/PatchTest_check.m
+++ b/Test Files/Check Files/PatchTest_check.m
@@ -37,9 +37,9 @@ d_exact(2:2:end) = (1-nu)*t/E.*y;
 stress_exact = [sigma*ones(1,Mesh.nn); sigma*ones(1,Mesh.nn); zeros(1,Mesh.nn)];
 
 % Calculate the error
-disp_er = norm(d - d_exact);
-stress_er = sqrt(sum((stress - stress_exact).^2,'all'));
-reaction_er = sum(Fext);
+disp_er = abs(norm(d - d_exact));
+stress_er = abs(sqrt(sum((stress - stress_exact).^2,'all')));
+reaction_er = abs(sum(Fext));
 
 end
 

--- a/Test Files/Config Files/ManufacturedSolution_PlaneStress_Q8.m
+++ b/Test Files/Config Files/ManufacturedSolution_PlaneStress_Q8.m
@@ -1,0 +1,150 @@
+function [Mesh, Material, BC, Control] = ManufacturedSolution_PlaneStress_Q8(config_dir, progress_on)
+global meshfilename quadorder E nu
+
+%% Mesh Properties
+    if progress_on
+        disp([num2str(toc),': Building Mesh...']);
+    end
+    
+    % Mesh formats: 
+    %   'MANUAL'    - In-house structured meshing
+    % 	'GMSH'      - Import .msh file from GMSH, structured or unstructured
+    MeshType = 'GMSH';        
+
+    
+    switch MeshType
+        case 'MANUAL'
+            % location of initial node [m] [x0;y0;z0] 
+            x1 = [0;0;0];
+            % number of space dimensions 
+            nsd = 2;
+            % size of domain [m] [Lx;Ly;Lz] 
+            L = [1;1];
+            % number of elements in each direction [nex; ney; nez] 
+            nex = [2;2]*20;
+            % element type ('Q4')
+            type = 'Q4';
+            
+            Mesh = BuildMesh_structured(nsd, x1, L, nex, type, progress_on);
+        case 'GMSH'
+            % Allows input of files from GMSH
+            % Note: the only currently supported .msh file formatting is
+            % Version 2 ASCII
+            % Ctrl + e to export the mesh, specify extension .msh, specify
+            % format Version 2 ASCII
+            meshFileName = meshfilename;
+
+            % number of space dimensions 
+            nsd = 2;
+            % Optional 5th input in case Q8 with reduced integration is desired
+            Q8_reduced = 'Q8'; %Do not consider this input if a case different than Q8 with reduced integration is desired
+            
+            Mesh = BuildMesh_GMSH(meshFileName, nsd, config_dir, progress_on, Q8_reduced);              
+    end    
+    
+
+%% Material Properties (Solid)
+
+    % NOTES-------------------------------------------------------------
+                                
+        % NOTE: anonymous functions are defined with respect to the variable x,
+        % which is a vector [x(1) x(2) x(3)] = [x y z]
+
+        % NOTE: Material properties must be continuous along an element, 
+        % otherwise, quadrature order must be increased significantly
+
+    % Young's modulus [Pa]
+    Material.E = @(x) E;  
+
+    % Constitutive law: 'PlaneStrain' or 'PlaneStress' 
+    Material.Dtype = 'PlaneStress'; 
+
+    % Thickness (set as default to 1)
+    Material.t = @(x) 1;
+
+    % Poisson's ratio (set as default to 0.3)
+    Material.nu = @(x) nu;
+
+    % Alternatively, import a material file
+    % Material = Material_shale();
+
+%% Boundary Conditions
+    % {TIPS}------------------------------------------------------------
+        % TIP selecting edges:
+        % bottom_nodes = find(Mesh.x(:,2)==0); 
+        % top_nodes = find(Mesh.x(:,2)==2);
+        % left_nodes = find(Mesh.x(:,1)==0);
+        % right_nodes = find(Mesh.x(:,1)==4);
+        % bottom_dof = [bottom_nodes*2 - 1; bottom_nodes*2];
+        % top_dof = [top_nodes*2 - 1;top_nodes*2];
+
+    % Dirichlet boundary conditions (essential) according to manufactured
+    % solution
+    % ux = x^5 + x*y^3 - y^6
+    % uy = x^5 + x*y^3 - y^6
+    % -----------------------------------------------------------------
+        BC.UU = @(x) x(:,1).^5 + x(:,1).*x(:,2).^3 - x(:,2).^6;
+        BC.VV = @(x) x(:,1).^5 + x(:,1).*x(:,2).^3 - x(:,2).^6;
+
+        % column vector of prescribed displacement dof  
+        BC.fix_disp_dof1 = Mesh.left_dof;
+        BC.fix_disp_dof2 = Mesh.right_dof;
+        BC.fix_disp_dof3 = Mesh.bottom_dof;
+        BC.fix_disp_dof4 = Mesh.top_dof;
+        BC.fix_disp_dof = unique([BC.fix_disp_dof1;BC.fix_disp_dof2;BC.fix_disp_dof3;BC.fix_disp_dof4]);
+
+        % prescribed displacement for each dof [u1; u2; ...] [m]
+        BC.fix_disp_value = zeros(length(BC.fix_disp_dof),1);
+        BC.fix_disp_value(1:2:end) = BC.UU([Mesh.x(BC.fix_disp_dof(2:2:end)/2,1),Mesh.x(BC.fix_disp_dof(2:2:end)/2,2)]);
+        BC.fix_disp_value(2:2:end) = BC.VV([Mesh.x(BC.fix_disp_dof(2:2:end)/2,1),Mesh.x(BC.fix_disp_dof(2:2:end)/2,2)]);
+
+    %% Neumann BC
+    % -----------------------------------------------------------------
+        % column vector of prescribed traction dofs
+        BC.traction_force_dof = [];
+
+        % magnitude of prescribed tractions [N]
+        BC.traction_force_dof_value = [];
+
+        % NOTE: this is slower than prescribing tractions at dofs
+        % column vector of prescribed traction nodes 
+        BC.traction_force_node = Mesh.right_nodes;  
+
+        % prescribed traction [t1x t1y;t2x t2y;...] [N]
+        Fnode = 1/(length(BC.traction_force_node) - 1);
+        BC.traction_force_value = Fnode*[zeros(size(BC.traction_force_node)), zeros(size(BC.traction_force_node))];
+    
+        % NOTE: point loads at any of the element nodes can also be 
+        % added as a traction.
+
+        % magnitude of distributed body force [N/m] [bx;by] according to
+        % the manufactured solution:
+        % bx = -E / (1-v^2) * ( 20x^3 + 3vy^2          + (1-v)/2*[ 6xy - 30y^4 + 3y^2 ])
+        % by = -E/  (1-v^2) * ( (1-v)/2*[3y^2 + 20x^3] +           3vy^2 + 6xy - 30y^4 )
+            % 1D: [N/m], 2D: [N/m2]
+        	% NOTE: if no body force, use '@(x)[]'
+         	% NOTE: anonymous functions is defined with respect to the 
+            %      variable x,  which is a vector [x(1) x(2)] = [x y]
+        BC.b = @(x)[-E / (1-nu^2)  * ( 20*x(1).^3 + 3*nu*x(2).^2              + (1-nu)/2*( 6*x(1).*x(2) - 30*x(2).^4 + 3*x(2).^2));
+                    -E / (1-nu^2)  * ( (1-nu)/2*( 3*x(2).^2  + 20*x(1).^3)    + 3*nu*x(2).^2 + 6*x(1).*x(2) - 30*x(2).^4 )];
+
+%% Computation controls
+
+        % quadrature order
+        Control.qo = quadorder;
+
+        % Nodal averaging for discontinuous variables (stress/strain)
+        % 'none', 'nodal'
+        Control.stress_calc = 'nodal';
+
+        % penalty parameter for solution of static problem with 
+        % LinearSolver3
+        Control.beta = 10^10;
+
+        % method used for solving linear problem:
+            % 'LinearSolver1'
+            % 'LinearSolver2'
+            % 'LinearSolver3'
+        Control.LinearSolver = 'LinearSolver1';
+ 
+end

--- a/Test Files/Config Files/PatchTestA_Q8.m
+++ b/Test Files/Config Files/PatchTestA_Q8.m
@@ -1,0 +1,148 @@
+function [Mesh, Material, BC, Control] = PatchTestA_Q8(config_dir, progress_on)
+    global E nu t quadorder meshfilename 
+
+%% Mesh Properties
+    if progress_on
+        disp([num2str(toc),': Building Mesh...']);
+    end
+    
+    % Mesh formats: 
+    %   'MANUAL'    - In-house structured meshing
+    % 	'GMSH'      - Import .msh file from GMSH, structured or unstructured
+    MeshType = 'GMSH';        
+
+    
+    switch MeshType
+        case 'MANUAL'
+            % location of initial node [m] [x0;y0;z0] 
+            x1 = [0;0;0];
+            % number of space dimensions 
+            nsd = 2;
+            % size of domain [m] [Lx;Ly;Lz] 
+            L = [1;1];
+            % number of elements in each direction [nex; ney; nez] 
+            nex = [2;2]*20;
+            % element type ('Q4')
+            type = 'Q4';
+            
+            Mesh = BuildMesh_structured(nsd, x1, L, nex, type, progress_on);
+        case 'GMSH'
+            % Allows input of files from GMSH
+            % Note: the only currently supported .msh file formatting is
+            % Version 2 ASCII
+            % Ctrl + e to export the mesh, specify extension .msh, specify
+            % format Version 2 ASCII
+            meshFileName = meshfilename;
+            % number of space dimensions 
+            nsd = 2;
+            % Optional 5th input in case Q8 with reduced integration is desired
+            Q8_reduced = 'Q8'; %Do not consider this input if a case different than Q8 with reduced integration is desired
+            
+            Mesh = BuildMesh_GMSH(meshFileName, nsd, config_dir, progress_on, Q8_reduced);               
+    end    
+    
+
+%% Material Properties (Solid)
+
+    % NOTES-------------------------------------------------------------
+                                
+        % NOTE: anonymous functions are defined with respect to the variable x,
+        % which is a vector [x(1) x(2) x(3)] = [x y z]
+
+        % NOTE: Material properties must be continuous along an element, 
+        % otherwise, quadrature order must be increased significantly
+
+    % Young's modulus [Pa]
+    Material.E = @(x) E;  
+
+    % Constitutive law: 'PlaneStrain' or 'PlaneStress' 
+    Material.Dtype = 'PlaneStress'; 
+
+    % Thickness (set as default to 1)
+    Material.t = @(x) 1;
+
+    % Poisson's ratio (set as default to 0.3)
+    Material.nu = @(x) nu;
+
+    % Alternatively, import a material file
+    % Material = Material_shale();
+
+%% Boundary Conditions
+    % {TIPS}------------------------------------------------------------
+        % TIP selecting edges:
+        % bottom_nodes = find(Mesh.x(:,2)==0); 
+        % top_nodes = find(Mesh.x(:,2)==2);
+        % left_nodes = find(Mesh.x(:,1)==0);
+        % right_nodes = find(Mesh.x(:,1)==4);
+        % bottom_dof = [bottom_nodes*2 - 1; bottom_nodes*2];
+        % top_dof = [top_nodes*2 - 1;top_nodes*2];
+
+    % Dirichlet boundary conditions (essential) according to exact solution
+    % ux = (1-nu)*t/E*x
+    % uy = (1-nu)*t/E*y
+    % -----------------------------------------------------------------
+        
+        BC.UU = @(x) (1-nu)*t/E*x(:,1);
+        BC.VV = @(x) (1-nu)*t/E*x(:,2);
+        
+        % column vector of prescribed displacement dof  
+        BC.fix_disp_dof = 1:Mesh.nDOF;
+
+        % prescribed displacement for each dof [u1; u2; ...] [m]
+        BC.fix_disp_value = zeros(length(BC.fix_disp_dof),1);  
+        BC.fix_disp_value(1:2:end) = BC.UU(Mesh.x);
+        BC.fix_disp_value(2:2:end) = BC.VV(Mesh.x);  
+
+    %% Neumann BC
+    % -----------------------------------------------------------------
+        % column vector of prescribed traction dofs
+        BC.traction_force_dof = [];
+
+        % magnitude of prescribed tractions [N]
+        BC.traction_force_dof_value = [];
+
+        % NOTE: this is slower than prescribing tractions at dofs
+        % column vector of prescribed traction nodes 
+        BC.traction_force_node = Mesh.right_nodes;  
+
+        % prescribed traction [t1x t1y;t2x t2y;...] [N]
+        Fnode = 1/(length(BC.traction_force_node) - 1);
+        BC.traction_force_value = Fnode*[zeros(size(BC.traction_force_node)), zeros(size(BC.traction_force_node))];
+        
+        % find the nodes in the top right and bottom right corners
+        toprightnode = find(Mesh.x(BC.traction_force_node,2) == max(Mesh.x(:,2)));
+        botrightnode = find(Mesh.x(BC.traction_force_node,2) == min(Mesh.x(:,2)));
+        
+        BC.traction_force_value(toprightnode,1) = BC.traction_force_value(toprightnode,1)/2;
+        BC.traction_force_value(botrightnode,1) = BC.traction_force_value(botrightnode,1)/2;
+    
+        % NOTE: point loads at any of the element nodes can also be 
+        % added as a traction.
+
+        % magnitude of distributed body force [N/m] [bx;by]
+            % 1D: [N/m], 2D: [N/m2]
+        	% NOTE: if no body force, use '@(x)[]'
+         	% NOTE: anonymous functions is defined with respect to the 
+            %      variable x,  which is a vector [x(1) x(2)] = [x y]
+        BC.b = @(x)[];    
+
+%% Computation controls
+
+        % quadrature order
+        Control.qo = quadorder;
+
+        % Nodal averaging for discontinuous variables (stress/strain)
+        % 'none', 'nodal', 'center'
+        Control.stress_calc = 'nodal';
+
+        % penalty parameter for solution of static problem with 
+        % LinearSolver3
+        Control.beta = 10^10;
+
+        % method used for solving linear problem:
+            % 'LinearSolver1'
+            % 'LinearSolver2'
+            % 'LinearSolver3'
+        Control.LinearSolver = 'LinearSolver1';
+ 
+end

--- a/Test Files/Config Files/PatchTestB_Q8.m
+++ b/Test Files/Config Files/PatchTestB_Q8.m
@@ -1,0 +1,151 @@
+function [Mesh, Material, BC, Control] = PatchTestB_Q8(config_dir, progress_on)
+    global E nu t quadorder meshfilename
+
+%% Mesh Properties
+    if progress_on
+        disp([num2str(toc),': Building Mesh...']);
+    end
+    % Mesh formats: 
+    %   'MANUAL'    - In-house structured meshing
+    % 	'GMSH'      - Import .msh file from GMSH, structured or unstructured
+    MeshType = 'GMSH';        
+
+    
+    switch MeshType
+        case 'MANUAL'
+            % location of initial node [m] [x0;y0;z0] 
+            x1 = [0;0;0];
+            % number of space dimensions 
+            nsd = 2;
+            % size of domain [m] [Lx;Ly;Lz] 
+            L = [1;1];
+            % number of elements in each direction [nex; ney; nez] 
+            nex = [2;2]*20;
+            % element type ('Q4')
+            type = 'Q4';
+            
+            Mesh = BuildMesh_structured(nsd, x1, L, nex, type, progress_on);
+        case 'GMSH'
+            % Allows input of files from GMSH
+            % Note: the only currently supported .msh file formatting is
+            % Version 2 ASCII
+            % Ctrl + e to export the mesh, specify extension .msh, specify
+            % format Version 2 ASCII
+            meshFileName = meshfilename;
+            % number of space dimensions 
+            nsd = 2;
+            % Optional 5th input in case Q8 with reduced integration is desired
+            Q8_reduced = 'Q8'; %Do not consider this input if a case different than Q8 with reduced integration is desired
+            
+            Mesh = BuildMesh_GMSH(meshFileName, nsd, config_dir, progress_on, Q8_reduced);                 
+    end    
+    
+
+%% Material Properties (Solid)
+
+    % NOTES-------------------------------------------------------------
+                                
+        % NOTE: anonymous functions are defined with respect to the variable x,
+        % which is a vector [x(1) x(2) x(3)] = [x y z]
+
+        % NOTE: Material properties must be continuous along an element, 
+        % otherwise, quadrature order must be increased significantly
+
+    % Young's modulus [Pa]
+    Material.E = @(x) E;  
+
+    % Constitutive law: 'PlaneStrain' or 'PlaneStress' 
+    Material.Dtype = 'PlaneStress'; 
+
+    % Thickness (set as default to 1)
+    Material.t = @(x) 1;
+
+    % Poisson's ratio (set as default to 0.3)
+    Material.nu = @(x) nu;
+
+    % Alternatively, import a material file
+    % Material = Material_shale();
+
+%% Boundary Conditions
+    % {TIPS}------------------------------------------------------------
+        % TIP selecting edges:
+        % bottom_nodes = find(Mesh.x(:,2)==0); 
+        % top_nodes = find(Mesh.x(:,2)==2);
+        % left_nodes = find(Mesh.x(:,1)==0);
+        % right_nodes = find(Mesh.x(:,1)==4);
+        % bottom_dof = [bottom_nodes*2 - 1; bottom_nodes*2];
+        % top_dof = [top_nodes*2 - 1;top_nodes*2];
+
+    % Dirichlet boundary conditions (essential) according to exact solution
+    % ux = (1-nu)*t/E*x
+    % uy = (1-nu)*t/E*y
+    % -----------------------------------------------------------------
+        
+        BC.UU = @(x) (1-nu)*t/E*x(:,1);
+        BC.VV = @(x) (1-nu)*t/E*x(:,2);
+        
+        % column vector of prescribed displacement dof  
+        BC.fix_disp_dof1 = Mesh.left_dof;
+        BC.fix_disp_dof2 = Mesh.right_dof;
+        BC.fix_disp_dof3 = Mesh.bottom_dof;
+        BC.fix_disp_dof4 = Mesh.top_dof;
+        BC.fix_disp_dof = unique([BC.fix_disp_dof1;BC.fix_disp_dof2;BC.fix_disp_dof3;BC.fix_disp_dof4]);
+
+        % prescribed displacement for each dof [u1; u2; ...] [m]
+        BC.fix_disp_value = zeros(length(BC.fix_disp_dof),1);
+        BC.fix_disp_value(1:2:end) = BC.UU([Mesh.x(BC.fix_disp_dof(2:2:end)/2,1),Mesh.x(BC.fix_disp_dof(2:2:end)/2,2)]);
+        BC.fix_disp_value(2:2:end) = BC.VV([Mesh.x(BC.fix_disp_dof(2:2:end)/2,1),Mesh.x(BC.fix_disp_dof(2:2:end)/2,2)]);  
+
+    %% Neumann BC
+    % -----------------------------------------------------------------
+        % column vector of prescribed traction dofs
+        BC.traction_force_dof = [];
+
+        % magnitude of prescribed tractions [N]
+        BC.traction_force_dof_value = [];
+
+        % NOTE: this is slower than prescribing tractions at dofs
+        % column vector of prescribed traction nodes 
+        BC.traction_force_node = Mesh.right_nodes;  
+
+        % prescribed traction [t1x t1y;t2x t2y;...] [N]
+        Fnode = 1/(length(BC.traction_force_node) - 1);
+        BC.traction_force_value = Fnode*[zeros(size(BC.traction_force_node)), zeros(size(BC.traction_force_node))];
+        
+        % find the nodes in the top right and bottom right corners
+        toprightnode = find(Mesh.x(BC.traction_force_node,2) == max(Mesh.x(:,2)));
+        botrightnode = find(Mesh.x(BC.traction_force_node,2) == min(Mesh.x(:,2)));
+        
+        BC.traction_force_value(toprightnode,1) = BC.traction_force_value(toprightnode,1)/2;
+        BC.traction_force_value(botrightnode,1) = BC.traction_force_value(botrightnode,1)/2;
+    
+        % NOTE: point loads at any of the element nodes can also be 
+        % added as a traction.
+
+        % magnitude of distributed body force [N/m] [bx;by]
+            % 1D: [N/m], 2D: [N/m2]
+        	% NOTE: if no body force, use '@(x)[]'
+         	% NOTE: anonymous functions is defined with respect to the 
+            %      variable x,  which is a vector [x(1) x(2)] = [x y]
+        BC.b = @(x)[];    
+
+%% Computation controls
+
+        % quadrature order
+        Control.qo = quadorder;
+
+        % Nodal averaging for discontinuous variables (stress/strain)
+        % 'none', 'nodal', 'center'
+        Control.stress_calc = 'nodal';
+
+        % penalty parameter for solution of static problem with 
+        % LinearSolver3
+        Control.beta = 10^10;
+
+        % method used for solving linear problem:
+            % 'LinearSolver1'
+            % 'LinearSolver2'
+            % 'LinearSolver3'
+        Control.LinearSolver = 'LinearSolver1';
+ 
+end

--- a/Test Files/Config Files/PatchTestC_Q8.m
+++ b/Test Files/Config Files/PatchTestC_Q8.m
@@ -1,0 +1,197 @@
+function [Mesh, Material, BC, Control] = PatchTestC_Q8(config_dir, progress_on)
+    global E nu t quadorder meshfilename
+%% Mesh Properties
+    if progress_on
+        disp([num2str(toc),': Building Mesh...']);
+    end
+    % Mesh formats: 
+    %   'MANUAL'    - In-house structured meshing
+    % 	'GMSH'      - Import .msh file from GMSH, structured or unstructured
+    MeshType = 'GMSH';        
+
+    
+    switch MeshType
+        case 'MANUAL'
+            % location of initial node [m] [x0;y0;z0] 
+            x1 = [0;0;0];
+            % number of space dimensions 
+            nsd = 2;
+            % size of domain [m] [Lx;Ly;Lz] 
+            L = [1;1];
+            % number of elements in each direction [nex; ney; nez] 
+            nex = [2;2]*20;
+            % element type ('Q4')
+            type = 'Q4';
+            
+            Mesh = BuildMesh_structured(nsd, x1, L, nex, type, progress_on);
+        case 'GMSH'
+            % Allows input of files from GMSH
+            % Note: the only currently supported .msh file formatting is
+            % Version 2 ASCII
+            % Ctrl + e to export the mesh, specify extension .msh, specify
+            % format Version 2 ASCII
+            meshFileName = meshfilename;
+            % number of space dimensions 
+            nsd = 2;
+            % Optional 5th input in case Q8 with reduced integration is desired
+            Q8_reduced = 'Q8'; %Do not consider this input if a case different than Q8 with reduced integration is desired
+            
+            Mesh = BuildMesh_GMSH(meshFileName, nsd, config_dir, progress_on, Q8_reduced);          
+    end    
+    
+
+%% Material Properties (Solid)
+
+
+    % NOTES-------------------------------------------------------------
+                                
+        % NOTE: anonymous functions are defined with respect to the variable x,
+        % which is a vector [x(1) x(2) x(3)] = [x y z]
+
+        % NOTE: Material properties must be continuous along an element, 
+        % otherwise, quadrature order must be increased significantly
+
+    % Young's modulus [Pa]
+    Material.E = @(x) E;  
+
+    % Constitutive law: 'PlaneStrain' or 'PlaneStress' 
+    Material.Dtype = 'PlaneStress'; 
+
+    % Thickness (set as default to 1)
+    Material.t = @(x) 1;
+
+    % Poisson's ratio (set as default to 0.3)
+    Material.nu = @(x) nu;
+
+    % Alternatively, import a material file
+    % Material = Material_shale();
+
+%% Boundary Conditions
+    % {TIPS}------------------------------------------------------------
+        % TIP selecting edges:
+        % bottom_nodes = find(Mesh.x(:,2)==0); 
+        % top_nodes = find(Mesh.x(:,2)==2);
+        % left_nodes = find(Mesh.x(:,1)==0);
+        % right_nodes = find(Mesh.x(:,1)==4);
+        % bottom_dof = [bottom_nodes*2 - 1; bottom_nodes*2];
+        % top_dof = [top_nodes*2 - 1;top_nodes*2];
+
+    % Dirichlet boundary conditions (essential) according to exact solution
+    % ux = (1-nu)*t/E*x
+    % uy = (1-nu)*t/E*y
+    % -----------------------------------------------------------------
+        
+        BC.UU = @(x) (1-nu)*t/E*x(:,1);
+        BC.VV = @(x) (1-nu)*t/E*x(:,2);
+        
+        % column vector of prescribed displacement dof  
+        topleftnode = Mesh.left_nodes(find(Mesh.x(Mesh.left_nodes,2) == max(Mesh.x(:,2))));
+        botleftnode = Mesh.left_nodes(find(Mesh.x(Mesh.left_nodes,2) == min(Mesh.x(:,2))));
+        
+        BC.fix_disp_dof1 = [Mesh.left_nodes*2-1];
+        BC.fix_disp_dof2 = Mesh.bottom_nodes*2;
+        
+        BC.fix_disp_dof = [BC.fix_disp_dof1;BC.fix_disp_dof2];
+
+        % prescribed displacement for each dof [u1; u2; ...] [m]
+        BC.fix_disp_value = zeros(length(BC.fix_disp_dof),1);
+        BC.fix_disp_value1 = BC.UU([Mesh.x(Mesh.left_nodes,1),Mesh.x(Mesh.left_nodes,2)]);
+        BC.fix_disp_value2 = BC.VV([Mesh.x(Mesh.bottom_nodes,1),Mesh.x(Mesh.bottom_nodes,2)]);
+        BC.fix_disp_value = [BC.fix_disp_value1;BC.fix_disp_value2];  
+
+    %% Neumann BC
+    % -----------------------------------------------------------------
+        % column vector of prescribed traction dofs
+        BC.traction_force_dof = [];
+
+        % magnitude of prescribed tractions [N]
+        BC.traction_force_dof_value = [];
+
+        % NOTE: this is slower than prescribing tractions at dofs
+        % column vector of prescribed traction nodes 
+        toprightnode = Mesh.right_nodes(Mesh.x(Mesh.right_nodes,2) == max(Mesh.x(:,2)));
+        index_right = Mesh.right_nodes ~= toprightnode;
+        index_top   = Mesh.top_nodes   ~= toprightnode;
+        
+        BC.traction_force_node = [Mesh.right_nodes(index_right);  Mesh.top_nodes(index_top); toprightnode];
+        
+        % prescribed traction [t1x t1y;t2x t2y;...] [N]
+        %t = 4;
+        if strcmp(Mesh.type, 'Q4') || strcmp(Mesh.type, 'T3')
+            Fright = t*max(Mesh.x(:,2))/(length(Mesh.right_nodes) - 1); % traction * 1 element length (assumed evenly distributed)
+            Ftop   = t*max(Mesh.x(:,1))/(length(Mesh.top_nodes)   - 1); % traction * 1 element length (assumed evenly distributed)
+            BC.traction_force_value =       [   Fright*ones(size(Mesh.right_nodes(index_right))),     zeros(size(Mesh.right_nodes(index_right)));      % right side nodes
+                                                zeros(size(Mesh.top_nodes(index_top))),               Ftop*ones(size(Mesh.top_nodes(index_top)));           % top side nodes
+                                                Fright*1/2,                                           Ftop*1/2                                           ]; % top right node
+
+            % find the nodes in the top left and bottom right corners
+            botrightnode = find(Mesh.x(BC.traction_force_node,2) == min(Mesh.x(:,2)));
+            topleftnode  = find(Mesh.x(BC.traction_force_node,1) == min(Mesh.x(:,1)));
+
+            BC.traction_force_value(botrightnode,1) = BC.traction_force_value(botrightnode,1)/2;
+            BC.traction_force_value(topleftnode,2) = BC.traction_force_value(topleftnode,2)/2;
+        elseif strcmp(Mesh.type, 'Q9') || strcmp(Mesh.type, 'T6') || strcmp(Mesh.type, 'Q8')
+            Fright = t*max(Mesh.x(:,2))/((length(Mesh.right_nodes) - 1)/2);
+            Ftop   = t*max(Mesh.x(:,1))/((length(Mesh.top_nodes)   - 1)/2);
+            BC.traction_force_value = zeros(length(BC.traction_force_node),2);
+            for n = 1:length(BC.traction_force_node)
+                if n <= length(Mesh.right_nodes(index_right)) % then node is on the right edge
+                    if any( BC.traction_force_node(n) == Mesh.conn(:,1:4),'all') % then node is a corner node
+                        BC.traction_force_value(n,:) = [Fright/3, 0];
+                    else % then node is a midside node
+                        BC.traction_force_value(n,:) = [Fright*2/3,0];
+                    end
+                elseif n == length(BC.traction_force_node) % then node is the top right node
+                        BC.traction_force_value(n,:) = [Fright/6, Ftop/6];
+                else % then node is on the top edge
+                    if any( BC.traction_force_node(n) == Mesh.conn(:,1:4),'all') % then node is a corner node
+                        BC.traction_force_value(n,:) = [0, Ftop/3];
+                    else % then node is a midside node
+                        BC.traction_force_value(n,:) = [0, Ftop*2/3];
+                    end
+                end
+            end
+            
+            % find the nodes in the top left and bottom right corners
+            botrightnode = find(Mesh.x(BC.traction_force_node,2) == min(Mesh.x(:,2)));
+            topleftnode  = find(Mesh.x(BC.traction_force_node,1) == min(Mesh.x(:,1)));
+
+            BC.traction_force_value(botrightnode,1) = BC.traction_force_value(botrightnode,1)/2;
+            BC.traction_force_value(topleftnode,2) = BC.traction_force_value(topleftnode,2)/2;
+            
+        else
+            error('Unsupported element type')
+        end
+  
+        
+    
+        % NOTE: point loads at any of the element nodes can also be 
+        % added as a traction.
+
+        % magnitude of distributed body force [N/m] [bx;by]
+            % 1D: [N/m], 2D: [N/m2]
+        	% NOTE: if no body force, use '@(x)[]'
+         	% NOTE: anonymous functions is defined with respect to the 
+            %      variable x,  which is a vector [x(1) x(2)] = [x y]
+        BC.b = @(x)[];    
+
+%% Computation controls
+
+        % quadrature order
+        Control.qo = quadorder;
+
+        % Nodal averaging for discontinuous variables (stress/strain)
+        % 'none', 'nodal', 'center'
+        Control.stress_calc = 'nodal';
+
+        % penalty parameter for solution of static problem with 
+        % LinearSolver3
+        Control.beta = 10^10;
+
+        % method used for solving linear problem:
+            % 'LinearSolver1'
+            % 'LinearSolver2'
+            % 'LinearSolver3'
+        Control.LinearSolver = 'LinearSolver1';
+ 
+end

--- a/Test Files/RunManSolQ8.m
+++ b/Test Files/RunManSolQ8.m
@@ -1,0 +1,91 @@
+% ------------------------------------------------------------------------
+% Runs unit test - Q9 manufactured solution convergence as a part of RunTests
+% ------------------------------------------------------------------------
+% Calculates the convergence rates of a uniform Q9 mesh using a
+% manufactured solution in which 
+% ux = x^5 + x*y^3 - y^6
+% uy = x^5 + x*y^3 - y^6
+% under plane stress conditions
+
+% Note: Q8 elements use Q9.msh files and central nodes are eliminated from
+% the mesh
+
+
+        testnum = testnum + 1;
+        testname = 'Q8 Convergence - Plane stress manufactured solution';
+        nameslist{testnum} = testname;
+       
+        % Create test VTK folder
+        if plot2vtk
+            folname = ['\Test',num2str(testnum)];
+            vtk_dir = fullfile(VTKFolder,folname);
+            if ~isfolder(vtk_dir) 
+                mkdir(vtk_dir)
+            end
+        end
+        % test runs 3 meshes, only finest mesh will be saved
+    
+        fprintf('\n\n Test %d : %s\n', testnum, testname)
+        % Step 1 - Run Simulation
+        global meshfilename quadorder E nu
+            E = 2230;
+            nu = 0.3; 
+            quadorder = 4;
+            config_name = 'ManufacturedSolution_PlaneStress_Q8';
+            
+            % Run coarse mesh
+            meshfilename = 'Mesh Files\Manufactured_coarseQ9.msh';
+            main
+
+            d_coarse = d;
+            stress_coarse = stress;
+            strain_coarse = strain;
+            Mesh_coarse = Mesh;
+
+
+            % Run fine mesh
+            meshfilename = 'Mesh Files\Manufactured_fineQ9.msh';
+            main
+
+            d_fine = d;
+            stress_fine = stress;
+            strain_fine = strain;
+            Mesh_fine = Mesh;
+
+            % Run finer mesh
+            meshfilename = 'Mesh Files\Manufactured_finerQ9.msh';
+            main
+            
+            d_finer = d;
+            stress_finer = stress;
+            strain_finer = strain;
+            Mesh_finer = Mesh;
+        
+        % Step 2 - Check results
+            [m_L2, m_e] = ManufacturedSolution_PlaneStress_check(d_coarse, d_fine, d_finer, ...
+                stress_coarse, stress_fine, stress_finer, strain_coarse, strain_fine, ...
+                strain_finer, Mesh_coarse, Mesh_fine, Mesh_finer);
+            
+            fprintf('\nQ8 L2-norm converges at a rate of %.2f',m_L2)
+            fprintf('\nQ8  e-norm converges at a rate of %.2f',m_e)
+            
+            convergence_tolerance = 0.05;
+            if m_L2 >= (3 - convergence_tolerance) && m_e >= (2 - convergence_tolerance)
+                test_pass = 1;
+            else
+                test_pass = 0;
+            end
+            
+        % Step 3 - Output results
+            if test_pass
+                fprintf('\nPASS\n')
+            else
+                fprintf('\n\nFAIL\n')
+            end
+        testpasssummary(testnum) = test_pass;
+
+        
+        % Step 4 - Cleanup
+        clearvars -except  curDir  ConfigDir ...
+                      ntests testpasssummary testnum nameslist...
+                      plot2vtk VTKFolder progress_on

--- a/Test Files/RunPatchTestAQ8.m
+++ b/Test Files/RunPatchTestAQ8.m
@@ -1,10 +1,13 @@
 % ------------------------------------------------------------------------
-% Runs unit test - Patch Test A Q9 as part of RunTests
+% Runs unit test - Patch Test A Q8 as part of RunTests
 % ------------------------------------------------------------------------
 % For Patch Test A, all nodes are restrained and nodal displacement values 
 % are specfied according to the exact solution. The error between the FEA
 % and exact solutions is then calculated. The FEA approximate solution
 % should be exact.
+
+% Note: Q8 elements use Q9.msh files and central nodes are eliminated from
+% the mesh
         
         testnum = testnum + 1;
         testname = 'Patch Test A - Q8 elements with reduced integration';

--- a/Test Files/RunPatchTestAQ8.m
+++ b/Test Files/RunPatchTestAQ8.m
@@ -40,9 +40,9 @@
         % Step 2 - Check results
         [disp_er, stress_er, reaction_er] = PatchTest_check(d, stress, Fext, Mesh);
         
-        fprintf('\nQ9-patch test A: Displacement error is %.2f',disp_er)
-        fprintf('\nQ9-patch test A: Stress error is %.2f',stress_er)
-        fprintf('\nQ9-patch test A: Reaction forces error is %.2f',reaction_er)
+        fprintf('\nQ8-patch test A: Displacement error is %.2f',disp_er)
+        fprintf('\nQ8-patch test A: Stress error is %.2f',stress_er)
+        fprintf('\nQ8-patch test A: Reaction forces error is %.2f',reaction_er)
         
         convergence_tolerance = 1e-10;
         if disp_er <= convergence_tolerance && stress_er <= convergence_tolerance && reaction_er <= convergence_tolerance 

--- a/Test Files/RunPatchTestAQ8.m
+++ b/Test Files/RunPatchTestAQ8.m
@@ -1,0 +1,63 @@
+% ------------------------------------------------------------------------
+% Runs unit test - Patch Test A Q9 as part of RunTests
+% ------------------------------------------------------------------------
+% For Patch Test A, all nodes are restrained and nodal displacement values 
+% are specfied according to the exact solution. The error between the FEA
+% and exact solutions is then calculated. The FEA approximate solution
+% should be exact.
+        
+        testnum = testnum + 1;
+        testname = 'Patch Test A - Q8 elements with reduced integration';
+        nameslist{testnum} = testname;
+       
+        % Create test VTK folder
+        if plot2vtk
+            folname = ['\Test',num2str(testnum)];
+            vtk_dir = fullfile(VTKFolder,folname);
+            if ~isfolder(vtk_dir) 
+                mkdir(vtk_dir)
+            end
+        end
+
+        
+        fprintf('\n\n Test %d : %s\n', testnum, testname)
+        % Step 1 - Run Simulation
+        global  E nu t meshfilename quadorder
+        t = 3.495; % applied traction (both directions)
+        E = 2540;  % elastic modulus
+        nu = 0.3;  % poisson's ratio
+        
+        meshfilename = 'Mesh Files\PatchTestQ9.msh';
+        quadorder = 3;
+
+        
+        config_name = 'PatchTestA_Q8';
+        main
+        
+        % Step 2 - Check results
+        [disp_er, stress_er, reaction_er] = PatchTest_check(d, stress, Fext, Mesh);
+        
+        fprintf('\nQ9-patch test A: Displacement error is %.2f',disp_er)
+        fprintf('\nQ9-patch test A: Stress error is %.2f',stress_er)
+        fprintf('\nQ9-patch test A: Reaction forces error is %.2f',reaction_er)
+        
+        convergence_tolerance = 1e-10;
+        if disp_er <= convergence_tolerance && stress_er <= convergence_tolerance && reaction_er <= convergence_tolerance 
+            test_pass = 1;
+        else
+            test_pass = 0;
+        end
+        
+        % Step 3 - Output results
+        if test_pass
+            fprintf('\nPASS Patch Test A\n')
+        else
+            fprintf('\n\nFAIL Patch Test A\n')
+        end
+        testpasssummary(testnum) = test_pass;
+
+        
+        % Step 4 - Cleanup
+        clearvars -except  curDir  ConfigDir ...
+                      ntests testpasssummary testnum nameslist...
+                      plot2vtk VTKFolder progress_on

--- a/Test Files/RunPatchTestBQ8.m
+++ b/Test Files/RunPatchTestBQ8.m
@@ -1,0 +1,63 @@
+% ------------------------------------------------------------------------
+% Runs unit test - Patch Test B Q9 as part of RunTests
+% ------------------------------------------------------------------------
+% For Patch Test B, only nodes 1-8 (nodes in the boundaries) are restrained
+% with their displacements specified according to the exact solution. The error between the FEA
+% and exact solutions is then calculated. The FEA approximate solution
+% should be exact.
+
+        testnum = testnum + 1;
+        testname = 'Patch Test B - Q8 elements with reduced integration';
+        nameslist{testnum} = testname;
+       
+        % Create test VTK folder
+        if plot2vtk
+            folname = ['\Test',num2str(testnum)];
+            vtk_dir = fullfile(VTKFolder,folname);
+            if ~isfolder(vtk_dir) 
+                mkdir(vtk_dir)
+            end
+        end
+
+        fprintf('\n\n Test %d : %s\n', testnum, testname)
+        % Step 1 - Run Simulation
+        global  E nu t meshfilename quadorder
+        t = 3.495; % applied traction (both directions)
+        E = 2540;  % elastic modulus
+        nu = 0.3;  % poisson's ratio
+        
+        meshfilename = 'Mesh Files\PatchTestQ9.msh';
+        quadorder = 3;
+        
+        config_name = 'PatchTestB_Q8';
+        main
+        
+        % Step 2 - Check results
+        [disp_er, stress_er, reaction_er] = PatchTest_check(d, stress, Fext, Mesh);
+        
+        fprintf('\nQ9-patch test B: Displacement error is %.2f',disp_er)
+        fprintf('\nQ9-patch test B: Stress error is %.2f',stress_er)
+        fprintf('\nQ9-patch test B: Reaction forces error is %.2f',reaction_er)
+        
+        convergence_tolerance = 1e-10;
+        if disp_er <= convergence_tolerance && stress_er <= convergence_tolerance && reaction_er <= convergence_tolerance 
+            test_pass = 1;
+        else
+            test_pass = 0;
+        end
+        
+        
+        % Step 3 - Output results
+        if test_pass
+            fprintf('\nPASS Patch Test B\n')
+        else
+            fprintf('\n\nFAIL Patch Test B\n')
+            return
+        end
+        testpasssummary(testnum) = test_pass;
+
+        
+        % Step 4 - Cleanup
+        clearvars -except  curDir  ConfigDir ...
+                      ntests testpasssummary testnum nameslist...
+                      plot2vtk VTKFolder progress_on

--- a/Test Files/RunPatchTestBQ8.m
+++ b/Test Files/RunPatchTestBQ8.m
@@ -38,9 +38,9 @@
         % Step 2 - Check results
         [disp_er, stress_er, reaction_er] = PatchTest_check(d, stress, Fext, Mesh);
         
-        fprintf('\nQ9-patch test B: Displacement error is %.2f',disp_er)
-        fprintf('\nQ9-patch test B: Stress error is %.2f',stress_er)
-        fprintf('\nQ9-patch test B: Reaction forces error is %.2f',reaction_er)
+        fprintf('\nQ8-patch test B: Displacement error is %.2f',disp_er)
+        fprintf('\nQ8-patch test B: Stress error is %.2f',stress_er)
+        fprintf('\nQ8-patch test B: Reaction forces error is %.2f',reaction_er)
         
         convergence_tolerance = 1e-10;
         if disp_er <= convergence_tolerance && stress_er <= convergence_tolerance && reaction_er <= convergence_tolerance 

--- a/Test Files/RunPatchTestBQ8.m
+++ b/Test Files/RunPatchTestBQ8.m
@@ -1,10 +1,13 @@
 % ------------------------------------------------------------------------
-% Runs unit test - Patch Test B Q9 as part of RunTests
+% Runs unit test - Patch Test B Q8 as part of RunTests
 % ------------------------------------------------------------------------
 % For Patch Test B, only nodes 1-8 (nodes in the boundaries) are restrained
 % with their displacements specified according to the exact solution. The error between the FEA
 % and exact solutions is then calculated. The FEA approximate solution
 % should be exact.
+
+% Note: Q8 elements use Q9.msh files and central nodes are eliminated from
+% the mesh
 
         testnum = testnum + 1;
         testname = 'Patch Test B - Q8 elements with reduced integration';

--- a/Test Files/RunPatchTestCQ8.m
+++ b/Test Files/RunPatchTestCQ8.m
@@ -42,9 +42,9 @@
         % Step 2 - Check results
         [disp_er, stress_er, reaction_er] = PatchTest_check(d, stress, Fext, Mesh);
         
-        fprintf('\nQ9-patch test C: Displacement error is %.2f',disp_er)
-        fprintf('\nQ9-patch test C: Stress error is %.2f',stress_er)
-        fprintf('\nQ9-patch test C: Reaction forces error is %.2f',reaction_er)
+        fprintf('\nQ8-patch test C: Displacement error is %.2f',disp_er)
+        fprintf('\nQ8-patch test C: Stress error is %.2f',stress_er)
+        fprintf('\nQ8-patch test C: Reaction forces error is %.2f',reaction_er)
         
         convergence_tolerance = 1e-10;
         if disp_er <= convergence_tolerance && stress_er <= convergence_tolerance && reaction_er <= convergence_tolerance 

--- a/Test Files/RunPatchTestCQ8.m
+++ b/Test Files/RunPatchTestCQ8.m
@@ -1,0 +1,66 @@
+% ------------------------------------------------------------------------
+% Runs unit test - Patch Test C as part of RunTests
+% ------------------------------------------------------------------------
+% Patch Test C is performed with node 1 fully restrained and nodes 4 and 8 
+% restrained only in the x -direction. Nodal forces are applied to nodes 2,
+% 3, and 6 in accordance with the values generated through the boundary 
+% tractions by sigma(x)=2. The error between the FEA
+% and exact solutions is then calculated. The FEA approximate solution
+% should be exact.
+
+       
+        testnum = testnum + 1;
+        testname = 'Patch Test C - Q8 elements with reduced integration';
+        nameslist{testnum} = testname;
+       
+        % Create test VTK folder
+        if plot2vtk
+            folname = ['\Test',num2str(testnum)];
+            vtk_dir = fullfile(VTKFolder,folname);
+            if ~isfolder(vtk_dir) 
+                mkdir(vtk_dir)
+            end
+        end
+
+        
+        fprintf('\n\n Test %d : %s\n', testnum, testname)
+        % Step 1 - Run Simulation
+        global  E nu t meshfilename quadorder
+        t = 3.495; % applied traction (both directions)
+        E = 2540;  % elastic modulus
+        nu = 0.3;  % poisson's ratio
+        
+        meshfilename = 'Mesh Files\PatchTestQ9.msh';
+        quadorder = 3;
+        
+        config_name = 'PatchTestC_Q8';
+        main
+        
+        % Step 2 - Check results
+        [disp_er, stress_er, reaction_er] = PatchTest_check(d, stress, Fext, Mesh);
+        
+        fprintf('\nQ9-patch test C: Displacement error is %.2f',disp_er)
+        fprintf('\nQ9-patch test C: Stress error is %.2f',stress_er)
+        fprintf('\nQ9-patch test C: Reaction forces error is %.2f',reaction_er)
+        
+        convergence_tolerance = 1e-10;
+        if disp_er <= convergence_tolerance && stress_er <= convergence_tolerance && reaction_er <= convergence_tolerance 
+            test_pass = 1;
+        else
+            test_pass = 0;
+        end
+        
+        % Step 3 - Output results
+        if test_pass
+            fprintf('\nPASS Patch Test C\n')
+        else
+            fprintf('\n\nFAIL Patch Test C\n')
+            return
+        end
+        testpasssummary(testnum) = test_pass;
+
+        
+        % Step 4 - Cleanup
+        clearvars -except  curDir  ConfigDir ...
+                      ntests testpasssummary testnum nameslist...
+                      plot2vtk VTKFolder progress_on

--- a/Test Files/RunPatchTestCQ8.m
+++ b/Test Files/RunPatchTestCQ8.m
@@ -1,5 +1,5 @@
 % ------------------------------------------------------------------------
-% Runs unit test - Patch Test C as part of RunTests
+% Runs unit test - Patch Test C Q8 as part of RunTests
 % ------------------------------------------------------------------------
 % Patch Test C is performed with node 1 fully restrained and nodes 4 and 8 
 % restrained only in the x -direction. Nodal forces are applied to nodes 2,
@@ -7,6 +7,9 @@
 % tractions by sigma(x)=2. The error between the FEA
 % and exact solutions is then calculated. The FEA approximate solution
 % should be exact.
+
+% Note: Q8 elements use Q9.msh files and central nodes are eliminated from
+% the mesh
 
        
         testnum = testnum + 1;


### PR DESCRIPTION
## What?
Add Q8 elements with reduced integration.
## Why?
Improves speed in comparison with Q9 elements.  
## How?
New shape functions for 8-node Serendipity Elements with reduced integration.
## Testing?
4 new test cases: patch tests A, B, C, and convergence for a plane stress manufactured solution.
## Anything Else?
- There is a new optional input for Q8 elements in BuildMesh_GMSH.
- Only works for meshes obtained from GMSH files. 