### PR TITLE
Tangent matrix pointer

### DIFF
--- a/Config Files/MasterConfigFile.m
+++ b/Config Files/MasterConfigFile.m
@@ -169,6 +169,9 @@ function [Mesh, Material, BC, Control] = MasterConfigFile(config_dir, progress_o
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
         
+    % Specify stiffness matrix calculation file    
+    Material.StiffnessMatrix = 'getK_elastic';
+    
     % number of material properties
     Material.nmp = 1;
 

--- a/Config Files/MasterConfigFile.m
+++ b/Config Files/MasterConfigFile.m
@@ -170,6 +170,7 @@ function [Mesh, Material, BC, Control] = MasterConfigFile(config_dir, progress_o
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
         
     % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD';
     Material.StiffnessMatrixFile = 'getK_elastic';
     Material.StressStrainFile = 'getStrain';
     

--- a/Config Files/MasterConfigFile.m
+++ b/Config Files/MasterConfigFile.m
@@ -169,8 +169,9 @@ function [Mesh, Material, BC, Control] = MasterConfigFile(config_dir, progress_o
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
         
-    % Specify stiffness matrix calculation file    
-    Material.StiffnessMatrix = 'getK_elastic';
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.StiffnessMatrixFile = 'getK_elastic';
+    Material.StressStrainFile = 'getStrain';
     
     % number of material properties
     Material.nmp = 1;

--- a/Functions/Assembly/getK.m
+++ b/Functions/Assembly/getK.m
@@ -32,6 +32,9 @@ function K = getK(Mesh, Quad, Material)
 
 % Acknowledgements: Chris Ladubec
 
+% initialize D matrix file pointer
+[~,DMatrix_functn] = fileparts(Material.ConstitutiveLawFile);
+
 % initialize stiffness matrix
 vec_size = Mesh.ne*(Mesh.nne * Mesh.nsd)^2; % vector size (solid dofs)
 row = zeros(vec_size, 1);                   % vector of row indices
@@ -56,7 +59,7 @@ for e = 1:Mesh.ne
         
     %% Constitutive matrix
         nMat = Mesh.MatList(e); % element material type
-        D = getD(Material.Prop(nMat).E, Material.Prop(nMat).nu, Mesh.nsd, Material.Dtype);
+        D = feval(DMatrix_functn, Material.Prop(nMat).E, Material.Prop(nMat).nu, Mesh.nsd, Material.Dtype);
         
     %% Shape functions and derivatives in parent coordinates
         W = Quad.W;

--- a/Functions/Assembly/getK_elastic.m
+++ b/Functions/Assembly/getK_elastic.m
@@ -1,0 +1,53 @@
+function [K, Fint] = getK_elastic(~, ~, ~, Klin, ~, d, ~, ~, ~, ~, ~, ~)
+%GETK_ELASTIC Stiffness matrix for iterative elastic case
+%   [K, Fint] = GETK_ELASTIC(Mesh, Quad, Material) returns the stiffness
+%   matrix and internal force vector for the iterative solver where the
+%   problem uses a linear elastic material
+%   
+%   Template file for other tangent matrix files 
+%   --------------------------------------------------------------------
+%   Accepted Inputs (in order)
+%   --------------------------------------------------------------------
+%   getK_elastic(Mesh, Quad, Material, Klin, M, d, dnm1, dnm2, stress, strain, dt, dtnm1)
+%   Mesh:       Structure array with the following fields, may be updated
+%               with new fields
+%               .ne:    Total number of elements in the mesh
+%               .nne:   Vector of number of nodes per element (size nsd x 1)
+%               .nsd:   Number of spatial dimensions
+%               .conn:  Array of element connectivity (size ne x nne)
+%               .x:     Array of nodal spatial locations for
+%                       undeformed mesh (size nn x nsd)
+%               .DOF:   Array of DOF indices (size nn x nsd)
+%               .nDOFe: Number of DOFs per element
+%               .nDOF:  Total number of DOFs
+%  
+%   Quad:       Structure array with the following fields, may be updated
+%               with new fields
+%               .W:      Vector of quadrature weights (size nq x 1)      
+%               .nq:     Number of quadrature points 
+%               .Nq:     Cell array (size nq x 1) with shape functions  
+%                        evaluated at each quadrature point
+%               .dNdxiq: Cell array (size nq x 1) with derivative of shape 
+%                        functions w.r.t. parent coordinates evaluated at 
+%                        each quadrature point
+% 
+%   Material:   Structure array with the following fields, may be updated
+%               with new fields
+%               .t:         Material thickness
+%
+%   Klin:       Linear elastic stiffness matrix
+%   M:          Mass matrix
+%   d:          unconverged degree of freedom vector at current timestep n and iteration
+%   dnm1:       converged degree of freedom vector at timestep n-1
+%   dnm2:       converged degree of freedom vector at timestep n-2
+%   stress:     stress in the body
+%   strain:     strain in the body
+%   dt:         timestep size between timesteps n-1 and n
+%   dtnm1:      timestep size between timesteps n-2 and n-1
+
+
+K = Klin;
+Fint = K*d;
+
+
+end

--- a/Functions/Assembly/getK_elastic.m
+++ b/Functions/Assembly/getK_elastic.m
@@ -1,8 +1,8 @@
-function [K, Fint] = getK_elastic(~, ~, ~, Klin, ~, d, ~, ~, ~, ~)
+function [K, R, Fint] = getK_elastic(~, ~, ~, Fext, Klin, ~, d, ~, ~, ~, ~)
 %GETK_ELASTIC Stiffness matrix for iterative elastic case
-%   [K, Fint] = GETK_ELASTIC(Mesh, Quad, Material) returns the stiffness
-%   matrix and internal force vector for the iterative solver where the
-%   problem uses a linear elastic material
+%   [K, R, Fint] = GETK_ELASTIC(Mesh, Quad, Material) returns the stiffness
+%   matrix K, the residual vector R, and the internal force vector for the 
+%   iterative solver where the problem uses a linear elastic material
 %   
 %   Template file for other tangent matrix files 
 %   --------------------------------------------------------------------
@@ -35,6 +35,7 @@ function [K, Fint] = getK_elastic(~, ~, ~, Klin, ~, d, ~, ~, ~, ~)
 %               with new fields
 %               .t:         Material thickness
 %
+%   Fext:       External force vector at timestep n
 %   Klin:       Linear elastic stiffness matrix
 %   M:          Mass matrix
 %   d:          unconverged degree of freedom vector at current timestep n and iteration
@@ -46,6 +47,7 @@ function [K, Fint] = getK_elastic(~, ~, ~, Klin, ~, d, ~, ~, ~, ~)
 
 K = Klin;
 Fint = K*d;
+R = Fext - Fint;
 
 
 end

--- a/Functions/Assembly/getK_elastic.m
+++ b/Functions/Assembly/getK_elastic.m
@@ -1,4 +1,4 @@
-function [K, Fint] = getK_elastic(~, ~, ~, Klin, ~, d, ~, ~, ~, ~, ~, ~)
+function [K, Fint] = getK_elastic(~, ~, ~, Klin, ~, d, ~, ~, ~, ~)
 %GETK_ELASTIC Stiffness matrix for iterative elastic case
 %   [K, Fint] = GETK_ELASTIC(Mesh, Quad, Material) returns the stiffness
 %   matrix and internal force vector for the iterative solver where the
@@ -40,8 +40,6 @@ function [K, Fint] = getK_elastic(~, ~, ~, Klin, ~, d, ~, ~, ~, ~, ~, ~)
 %   d:          unconverged degree of freedom vector at current timestep n and iteration
 %   dnm1:       converged degree of freedom vector at timestep n-1
 %   dnm2:       converged degree of freedom vector at timestep n-2
-%   stress:     stress in the body
-%   strain:     strain in the body
 %   dt:         timestep size between timesteps n-1 and n
 %   dtnm1:      timestep size between timesteps n-2 and n-1
 

--- a/Functions/Main/main_nonlinear.m
+++ b/Functions/Main/main_nonlinear.m
@@ -58,7 +58,9 @@
     M = 0; % placeholder
     
     % Create tangent matrix function pointer
-    [~,stiffnessmatrix_name] = fileparts(Material.StiffnessMatrix);
+    [~,stiffnessmatrixfile_name] = fileparts(Material.StiffnessMatrixFile);
+    [~,stressstrainfile_name] = fileparts(Material.StressStrainFile);
+
     
 
 %% Define initial conditions
@@ -145,7 +147,7 @@ end
         d = d + Dd;
         
         % Compute nonlinear stiffness matrix and internal forces
-        [K, Fint] = feval(stiffnessmatrix_name, Mesh, Quad, Material, Klin, M, d, dnm1, dnm2, stress, strain, dt, dtnm1) ; 
+        [K, Fint] = feval(stiffnessmatrixfile_name, Mesh, Quad, Material, Klin, M, d, dnm1, dnm2, stress, strain, dt, dtnm1) ; 
 
         % Calculate residual vector at the end of each iteration
         Dd = zeros(Mesh.nsd*Mesh.nn,1);
@@ -187,8 +189,7 @@ end
         if progress_on
             disp([num2str(toc),': Post-Processing...']);
         end
-        [strain, stress] = getStrain(d, Mesh, Material, Control.stress_calc, Quad);   
-    % Todo: Create a new function for calculation of stress and strain in nonlinear cases
+        [strain, stress] = feval(stressstrainfile_name, d, Mesh, Material, Control.stress_calc, Quad);   
 
 
     % Write to vtk

--- a/Functions/Main/main_nonlinear.m
+++ b/Functions/Main/main_nonlinear.m
@@ -147,7 +147,7 @@ end
         d = d + Dd;
         
         % Compute nonlinear stiffness matrix and internal forces
-        [K, Fint] = feval(stiffnessmatrixfile_name, Mesh, Quad, Material, Klin, M, d, dnm1, dnm2, stress, strain, dt, dtnm1) ; 
+        [K, Fint] = feval(stiffnessmatrixfile_name, Mesh, Quad, Material, Klin, M, d, dnm1, dnm2, dt, dtnm1) ; 
 
         % Calculate residual vector at the end of each iteration
         Dd = zeros(Mesh.nsd*Mesh.nn,1);

--- a/Functions/Main/main_nonlinear.m
+++ b/Functions/Main/main_nonlinear.m
@@ -75,7 +75,7 @@
     
     % Export initial conditions
         % Strain
-        [strain, stress] = getStrain(d0, Mesh, Material, Control.stress_calc, Quad);   
+        [strain, stress] = feval(stressstrainfile_name, d0, Mesh, Material, Control.stress_calc, Quad);   
 
     % Internal force vectors
         Fint = K*d0;

--- a/Functions/Main/setDefaults.m
+++ b/Functions/Main/setDefaults.m
@@ -118,10 +118,14 @@ function [Mesh, Material, BC, Control] = setDefaults(Mesh, Material, BC, Control
         err_mat = sprintf('%s\t\t\tError #%d\t:\t Model thickness is not defined - Define Material.t\n',err_mat,err_count);
     end
     
-    if ~isfield(Material, 'StiffnessMatrix')
-        Material.StiffnessMatrix = 'getK_elastic';
+    if ~isfield(Material, 'StiffnessMatrixFile')
+        Material.StiffnessMatrixFile = 'getK_elastic';
         err_mat = sprintf('%s\t\t\tError #%d\t:\t Tangent matrix type not defined, set to linear elastic\n',err_mat,err_count);
-
+    end
+    
+    if ~isfield(Material, 'StressStrainFile')
+        Material.StressStrainFile = 'getStrain';
+        err_mat = sprintf('%s\t\t\tError #%d\t:\t Stress-Strain type not defined, set to linear elastic\n',err_mat,err_count);
     end
    
 %% Boundary conditions

--- a/Functions/Main/setDefaults.m
+++ b/Functions/Main/setDefaults.m
@@ -117,6 +117,12 @@ function [Mesh, Material, BC, Control] = setDefaults(Mesh, Material, BC, Control
         err_count = err_count+1;
         err_mat = sprintf('%s\t\t\tError #%d\t:\t Model thickness is not defined - Define Material.t\n',err_mat,err_count);
     end
+    
+    if ~isfield(Material, 'StiffnessMatrix')
+        Material.StiffnessMatrix = 'getK_elastic';
+        err_mat = sprintf('%s\t\t\tError #%d\t:\t Tangent matrix type not defined, set to linear elastic\n',err_mat,err_count);
+
+    end
    
 %% Boundary conditions
     err_BC = sprintf('\t\tBoundary conditions \n');

--- a/Functions/Main/setDefaults.m
+++ b/Functions/Main/setDefaults.m
@@ -120,17 +120,20 @@ function [Mesh, Material, BC, Control] = setDefaults(Mesh, Material, BC, Control
     
     if ~isfield(Material, 'StiffnessMatrixFile')
         Material.StiffnessMatrixFile = 'getK_elastic';
-        err_mat = sprintf('%s\t\t\tError #%d\t:\t Tangent matrix type not defined, set to linear elastic\n',err_mat,err_count);
+        war_count = war_count+1;
+        war_mat = sprintf('%s\t\t\tError #%d\t:\t Tangent matrix type not defined, set to linear elastic\n',err_mat,err_count);
     end
     
     if ~isfield(Material, 'StressStrainFile')
         Material.StressStrainFile = 'getStrain';
-        err_mat = sprintf('%s\t\t\tError #%d\t:\t Stress-Strain type not defined, set to linear elastic\n',err_mat,err_count);
+        war_count = war_count+1;
+        war_mat = sprintf('%s\t\t\tError #%d\t:\t Stress-Strain type not defined, set to linear elastic\n',err_mat,err_count);
     end
     
     if ~isfield(Material, 'ConstitutiveLawFile')
         Material.ConstitutiveLawFile = 'getD';
-        err_mat = sprintf('%s\t\t\tError #%d\t:\t Constitutive law file pointer not defined, set to linear elastic\n',err_mat,err_count);
+        war_count = war_count+1;
+        war_mat = sprintf('%s\t\t\tError #%d\t:\t Constitutive law file pointer not defined, set to linear elastic\n',err_mat,err_count);
     end
    
    

--- a/Functions/Main/setDefaults.m
+++ b/Functions/Main/setDefaults.m
@@ -127,6 +127,12 @@ function [Mesh, Material, BC, Control] = setDefaults(Mesh, Material, BC, Control
         Material.StressStrainFile = 'getStrain';
         err_mat = sprintf('%s\t\t\tError #%d\t:\t Stress-Strain type not defined, set to linear elastic\n',err_mat,err_count);
     end
+    
+    if ~isfield(Material, 'ConstitutiveLawFile')
+        Material.ConstitutiveLawFile = 'getD';
+        err_mat = sprintf('%s\t\t\tError #%d\t:\t Constitutive law file pointer not defined, set to linear elastic\n',err_mat,err_count);
+    end
+   
    
 %% Boundary conditions
     err_BC = sprintf('\t\tBoundary conditions \n');

--- a/Test Files/Config Files/CantileverBeam.m
+++ b/Test Files/Config Files/CantileverBeam.m
@@ -159,6 +159,11 @@ function [Mesh, Material, BC, Control] = CantileverBeam(config_dir, progress_on)
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
 
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD';
+    Material.StiffnessMatrixFile = 'getK_elastic';
+    Material.StressStrainFile = 'getStrain';
+
     % number of material properties
     Material.nmp = 1;
         

--- a/Test Files/Config Files/CricularInclusion.m
+++ b/Test Files/Config Files/CricularInclusion.m
@@ -164,6 +164,11 @@ function [Mesh, Material, BC, Control] = CricularInclusion(config_dir, progress_
         % for different materials are saved in Material.Prop.
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
+
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD';
+    Material.StiffnessMatrixFile = 'getK_elastic';
+    Material.StressStrainFile = 'getStrain';
         
     % number of material properties
     Material.nmp = 2;

--- a/Test Files/Config Files/ManufacturedSolution_DirichletTime.m
+++ b/Test Files/Config Files/ManufacturedSolution_DirichletTime.m
@@ -169,6 +169,11 @@ global Omega1 Omega2 E nu
         % for different materials are saved in Material.Prop.
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
+
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD';
+    Material.StiffnessMatrixFile = 'getK_elastic';
+    Material.StressStrainFile = 'getStrain';
         
     % number of material properties
     Material.nmp = 1;

--- a/Test Files/Config Files/ManufacturedSolution_PlaneStrain.m
+++ b/Test Files/Config Files/ManufacturedSolution_PlaneStrain.m
@@ -56,6 +56,11 @@ global meshfilename quadorder E nu
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
 
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD';
+    Material.StiffnessMatrixFile = 'getK_elastic';
+    Material.StressStrainFile = 'getStrain';
+
     % number of material properties
     Material.nmp = 1;
         

--- a/Test Files/Config Files/ManufacturedSolution_PlaneStress.m
+++ b/Test Files/Config Files/ManufacturedSolution_PlaneStress.m
@@ -56,6 +56,11 @@ global meshfilename quadorder E nu
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
 
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD';
+    Material.StiffnessMatrixFile = 'getK_elastic';
+    Material.StressStrainFile = 'getStrain';
+
     % number of material properties
     Material.nmp = 1;
         

--- a/Test Files/Config Files/ManufacturedSolution_PlaneStress_Q8.m
+++ b/Test Files/Config Files/ManufacturedSolution_PlaneStress_Q8.m
@@ -58,6 +58,11 @@ global meshfilename quadorder E nu
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
 
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD';
+    Material.StiffnessMatrixFile = 'getK_elastic';
+    Material.StressStrainFile = 'getStrain';
+
     % number of material properties
     Material.nmp = 1;
     

--- a/Test Files/Config Files/PatchTestA.m
+++ b/Test Files/Config Files/PatchTestA.m
@@ -54,6 +54,11 @@ function [Mesh, Material, BC, Control] = PatchTestA(config_dir, progress_on)
         % for different materials are saved in Material.Prop.
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
+
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD';
+    Material.StiffnessMatrixFile = 'getK_elastic';
+    Material.StressStrainFile = 'getStrain';
         
     % number of material properties
     Material.nmp = 1;

--- a/Test Files/Config Files/PatchTestA_Q8.m
+++ b/Test Files/Config Files/PatchTestA_Q8.m
@@ -57,6 +57,11 @@ function [Mesh, Material, BC, Control] = PatchTestA_Q8(config_dir, progress_on)
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
 
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD';
+    Material.StiffnessMatrixFile = 'getK_elastic';
+    Material.StressStrainFile = 'getStrain';
+
     % number of material properties
     Material.nmp = 1;
     

--- a/Test Files/Config Files/PatchTestB.m
+++ b/Test Files/Config Files/PatchTestB.m
@@ -54,6 +54,11 @@ function [Mesh, Material, BC, Control] = PatchTestB(config_dir, progress_on)
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
 
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD';
+    Material.StiffnessMatrixFile = 'getK_elastic';
+    Material.StressStrainFile = 'getStrain';
+
     % number of material properties
     Material.nmp = 1;
         

--- a/Test Files/Config Files/PatchTestB_Q8.m
+++ b/Test Files/Config Files/PatchTestB_Q8.m
@@ -56,6 +56,11 @@ function [Mesh, Material, BC, Control] = PatchTestB_Q8(config_dir, progress_on)
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
 
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD';
+    Material.StiffnessMatrixFile = 'getK_elastic';
+    Material.StressStrainFile = 'getStrain';
+
     % number of material properties
     Material.nmp = 1;
     

--- a/Test Files/Config Files/PatchTestC.m
+++ b/Test Files/Config Files/PatchTestC.m
@@ -54,6 +54,11 @@ function [Mesh, Material, BC, Control] = PatchTestC(config_dir, progress_on)
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
 
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD';
+    Material.StiffnessMatrixFile = 'getK_elastic';
+    Material.StressStrainFile = 'getStrain';
+
     % number of material properties
     Material.nmp = 1;
         

--- a/Test Files/Config Files/PatchTestC_Q8.m
+++ b/Test Files/Config Files/PatchTestC_Q8.m
@@ -56,6 +56,11 @@ function [Mesh, Material, BC, Control] = PatchTestC_Q8(config_dir, progress_on)
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
 
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD';
+    Material.StiffnessMatrixFile = 'getK_elastic';
+    Material.StressStrainFile = 'getStrain';
+
     % number of material properties
     Material.nmp = 1;
     

--- a/Test Files/Config Files/PlateWithHole.m
+++ b/Test Files/Config Files/PlateWithHole.m
@@ -159,6 +159,11 @@ function [Mesh, Material, BC, Control] = PlateWithHole(config_dir, progress_on)
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
 
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD';
+    Material.StiffnessMatrixFile = 'getK_elastic';
+    Material.StressStrainFile = 'getStrain';
+
     % number of material properties
     Material.nmp = 1;
         

--- a/Test Files/Config Files/Test1D.m
+++ b/Test Files/Config Files/Test1D.m
@@ -162,6 +162,11 @@ function [Mesh, Material, BC, Control] = Test1D(config_dir, progress_on)
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
 
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD';
+    Material.StiffnessMatrixFile = 'getK_elastic';
+    Material.StressStrainFile = 'getStrain';
+
     % number of material properties
     Material.nmp = 1;
         

--- a/Test Files/Config Files/UnstructuredMeshTest.m
+++ b/Test Files/Config Files/UnstructuredMeshTest.m
@@ -51,6 +51,10 @@ function [Mesh, Material, BC, Control] = UnstructuredMeshTest(config_dir, progre
         % for different materials are saved in Material.Prop.
         % For example, Young's modulus and Poisson's ratio of ith material will be saved in
         % Material.Prop(i).E and Material.Prop(i).nu, respectively.
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD';
+    Material.StiffnessMatrixFile = 'getK_elastic';
+    Material.StressStrainFile = 'getStrain';
 
     % number of material properties
     Material.nmp = 1;


### PR DESCRIPTION
## What?
Replace the direct reference to the getK function with function pointers to a new file that calculates the tangent matrix and internal forces vector. Function pointers were also created to the getStrain function.
## Why?
To create a framework using the non-linear Newton-Raphson solver that enables a modular swapping of different tangent matrix calculations for different non-linear material types.
## How?
The user specifies the name of the function they plan to use to calculate the tangent matrix and internal forces. The main file uses the feval function to evaluate this function.
## Testing?
MainConfigFile, RunTests
## Anything else?
I tried to future-proof the inputs to the general tangent matrix calculation function by including additional inputs that are not currently in use. These include **d**-vectors from previous timesteps, the linear **M** and **K** matrices, and timestep sizes from the current and previous timesteps.