### PR TITLE
Nonlinearelastic

### DIFF
--- a/Config Files/MasterConfigFile.m
+++ b/Config Files/MasterConfigFile.m
@@ -296,6 +296,11 @@ function [Mesh, Material, BC, Control] = MasterConfigFile(config_dir, progress_o
         % debugging and testing purposes only, vtk files are otherwise
         % recommended
         Control.dSave     = 0; 
+        % Plot load vs displacement curve (if not included, default is set
+        % to 0)
+        Control.plotLoadDispl = 0;
+        % DOF to plot (only necessary if Control.plotLoadDispl = 1)
+        Control.plotAt = 0; % [add DOF number]
         
         % Newton Raphson controls
         Control.r_tol = 1e-5; % Tolerance on residual forces

--- a/Config Files/NLElastic_1DBar.m
+++ b/Config Files/NLElastic_1DBar.m
@@ -1,0 +1,298 @@
+function [Mesh, Material, BC, Control] = NLElastic_1DBar(config_dir, progress_on)
+%PLATENLELASTIC Mesh, material parameters, boundary conditions, 
+%and control parameters
+%   Mesh = PLATENLELASTIC() is a structure array with the
+%   following fields: 
+%       .type:          the topological class of finite element; it is in 
+%                       the general form 'topology-#of nodes' ie a three 
+%                       node triangle is T3 a four node quadralateral is 
+%                       Q4 a 4 node tetrahedra is H4 a 27 node brick is 
+%                       B27 etc. Presently defined are L2, Q4, and Q9. 
+%       .nsd:           Number of spatial dimensions
+%       .ne:            Total number of elements in the mesh
+%       .nne:           Vector of number of nodes per element (size nsd x 1)
+%       .nn:            Total number of nodes 
+%       .nDOFe:         Number of DOFs per element
+%       .nDOF:          Total number of DOFs
+%       .x:             Array of nodal spatial locations for
+%                       undeformed mesh (size nn x nsd)
+%       .conn:          Array of element connectivity (size ne x nne)
+%       .eneighbours:   Array of neighbouring elements (size ne x nneighbours
+%                       in which nneighbours is 1 for 1D elements and 4
+%                       for 2D elements)
+%       .DOF:           Array of DOF indices (size nn x nsd)
+%       .nodeconn:      Array of nodal connectivity (size nn x 8)
+%                       containing the indices of elements connected to 
+%                       each node
+%       .left_nodes     Nodes on the left edge of the domain
+%       .left_dof       DOFs on the left edge of the domain
+%       .right_nodes    Nodes on the right edge of the domain
+%       .right_dof      DOFs on the right edge of the domain
+%       .xdofs          DOFs in the x-direction
+%       .ydofs          DOFs in the y-direction
+%       .zdofs          DOFs in the z-direction
+%   Two-dimensional meshes also contain the fields,
+%       .top_nodes      Nodes on the top edge of the domain
+%       .top_dof        DOFs on the top edge of the domain
+%       .top_dofx       DOFs on the top boundary in the x-direction
+%       .top_dofy       DOFs on the top boundary in the y-direction
+%       .bottom_nodes   Nodes on the bottom edge of the domain
+%       .bottom_dof     DOFs on the bottom edge of the domain
+%       .bottom_dofx    DOFs on the bottom boundary in the x-direction
+%       .bottom_dofy    DOFs on the bottom boundary in the y-direction
+%       .left_dofx      DOFs on the left boundary in the x-direction
+%       .left_dofy      DOFs on the left boundary in the y-direction
+%       .right_dofx     DOFs on the right boundary in the x-direction
+%       .right_dofy     DOFs on the right boundary in the y-direction
+%   Three-dimensional meshes also contain the fields, 
+%       .near_nodes     nodes on the nearest face of the domain
+%       .near_dof       DOFs on the nearest face of the domain
+%       .near_dofx      DOFs on the near face in the x-direction
+%       .near_dofy      DOFs on the near face in the y-direction
+%       .near_dofz      DOFs on the near face in the z-direction
+%       .far_nodes      Nodes on the farthest face of the domain
+%       .far_dof        DOFs on the farthest face of the domain
+%       .far_dofx       DOFs on the far face in the x-direction
+%       .far_dofy       DOFs on the far face in the y-direction
+%       .far_dofz       DOFs on the far face in the z-direction
+%       .left_dofz      DOFs on the left face in the z-direction
+%       .right_dofz     DOFs on the right face in the z-direction
+%       .top_dofz       DOFs on the top face in the z-direction
+%       .bottom_dofz    DOFs on the bottom face in the z-direction
+%       
+%   Mesh = PLATENLELASTIC(config_dir) defines the mesh using GMSH file 
+%   import located in the directory config_dir
+%
+%   [Mesh, Material] = PLATENLELASTIC() also returns a
+%   structure array with the following fields: 
+%       .nmp:           number of material properties
+%       .Prop:          Material properties
+%       .Prop.E:        Modulus of elasticity
+%       .Prop.nu:       Poisson's ratio
+%       .Prop.Dtype:    2D approximation ('PlaneStrain' or 'PlainStress')
+%       .Prop.t:        Material thickness
+% 
+%   [Mesh, Material, BC] = PLATENLELASTIC() also returns a structure
+%   array with the following fields: 
+%       .fix_disp_dof:              Column vector of degrees of freedom 
+%                                   with prescribed displacements
+%                                   (size nfixed x 1)
+%       .fix_disp_value             Column vector of prescribed 
+%                                   displacements (size nfixed x 1)
+%       .traction_force_dof         Column vector of degrees of freedom
+%                                   with prescribed tractions
+%       .traction_force_dof_value   Column vector of prescribed tractions
+%                                   on DOF
+%       .traction_force_node        Column vector of nodes with 
+%                                   prescribed tractions
+%       .traction_force_value       Column vector of prescribed tractions
+%                                   on nodes
+%       .b                          Anonymous function of distributed
+%                                   body force (size 1 x nsd)
+% 
+%   [Mesh, Material, BC, Control] = PLATENLELASTIC() also returns a 
+%   structure array with the following fields: 
+%       .qo:            Quadrature order
+%       .stress_calc    Calculation of values for discontinous variables
+%                       ('none', 'nodal', 'center', 'L2projection')
+%       .beta:          Penalty parameter  
+%       .LinearSolver   Method used for solving linear problem:
+%                       'LinearSolver1': Partitioning
+%                       'LinearSolver2': Zeroing DOFs in stiffness matrix 
+%                                        corresponding to essential boundaries
+%                       'LinearSolver3': Penalty method
+%   --------------------------------------------------------------------
+%   Input
+%   --------------------------------------------------------------------
+%   config_dir:     (OPTIONAL) File path for the directory where 
+%                   unstructured mesh is stored
+
+%% Mesh Properties
+    if progress_on
+        disp([num2str(toc),': Building Mesh...']);
+    end
+    
+    % Mesh formats: 
+    %   'MANUAL'- In-house structured meshing
+    % 	'GMSH'  - Import .msh file from GMSH, structured or unstructured
+    %   'EXCEL' - Import .xlsx file, structured or unstructured
+    MeshType = 'MANUAL';        
+    
+    switch MeshType
+        case 'MANUAL'
+            % location of initial node [m] [x0;y0;z0] 
+            x1 = [0;0;0];
+            % number of space dimensions 
+            nsd = 1;
+            % size of domain [m] [Lx;Ly;Lz] 
+            L = 2.35;
+            % number of elements in each direction [nex; ney; nez] 
+            nex = 1;
+            % element type ('Q4')
+            type = 'L2';
+            
+            Mesh = BuildMesh_structured(nsd, x1, L, nex, type, progress_on);
+        case 'GMSH'
+            % Allows input of files from GMSH
+            % Note: the only currently supported .msh file formatting is
+            % Version 2 ASCII
+            % Ctrl + e to export the mesh, specify extension .msh, specify
+            % format Version 2 ASCII
+            meshFileName = 'Unstructured_sample.msh';
+            % number of space dimensions 
+            nsd = 2;
+            % Optional 5th input in case Q8 with reduced integration is desired
+            Q8_reduced = 'Q8'; %Do not consider this input if a case different than Q8 with reduced integration is desired
+            
+            Mesh = BuildMesh_GMSH(meshFileName, nsd, config_dir, progress_on);            
+%             Mesh = BuildMesh_GMSH(meshFileName, nsd, config_dir, progress_on,Q8_reduced);  
+        case 'EXCEL'
+            meshFileName = 'CricularInclusion.xlsx';
+            % number of space dimensions
+            nsd = 2;
+            
+            Mesh = BuildMesh_EXCEL(meshFileName, nsd, config_dir, progress_on);
+    end    
+    
+%% Material Properties (Solid)
+
+    % NOTES-------------------------------------------------------------
+                                
+        % NOTE: anonymous functions are defined with respect to the variable x,
+        % which is a vector [x(1) x(2) x(3)] = [x y z]
+
+        % NOTE: Material properties must be continuous along an element, 
+        % otherwise, quadrature order must be increased significantly
+        
+        % NOTE: Number of material properties can be more than one. Properties
+        % for different materials are saved in Material.Prop.
+        % For example, Young's modulus and Poisson's ratio of ith material will be saved in
+        % Material.Prop(i).E and Material.Prop(i).nu, respectively.
+        
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD_NLelastic';
+    Material.StiffnessMatrixFile = 'getK_NLelastic';
+    Material.StressStrainFile = 'getStrain_NLelastic';
+    
+    % number of material properties
+    Material.nmp = 1;
+
+    % Properties material 1
+    Material.Prop(1).E = 2e11; % Young's modulus [Pa]
+    Material.Prop(1).E1 = 1e20; % Young's modulus [Pa]
+    Material.Prop(1).nu = 0.3; % Poisson's ratio
+    
+    % type of material per element
+    Mesh.MatList = zeros(Mesh.ne, 1, 'int8');
+    
+    % assign material type to elements
+    Mesh.MatList(:) = 1;
+
+    % Constitutive law: 'PlaneStrain' or 'PlaneStress' 
+    Material.Dtype = 'PlaneStress'; 
+
+    % Thickness (set as default to 1)
+    % 1D: [m2], 2D: [m]
+    Material.t = @(x) 1;
+
+    % Alternatively, import a material file
+    % Material = Material_shale();
+
+%% Boundary Conditions
+    % {TIPS}------------------------------------------------------------
+        % TIP selecting edges:
+        % bottom_nodes = find(Mesh.x(:,2)==0); 
+        % top_nodes = find(Mesh.x(:,2)==2);
+        % left_nodes = find(Mesh.x(:,1)==0);
+        % right_nodes = find(Mesh.x(:,1)==4);
+        % bottom_dof = [bottom_nodes*2 - 1; bottom_nodes*2];
+        % top_dof = [top_nodes*2 - 1;top_nodes*2];
+
+    % Dirichlet boundary conditions (essential)
+    % -----------------------------------------------------------------
+        % column vector of prescribed displacement dof  
+        BC.fix_disp_dof = Mesh.left_dof;
+
+        % prescribed displacement for each dof [u1; u2; ...] [m]
+        BC.fix_disp_value = @(t) zeros(length(BC.fix_disp_dof),1);  
+
+    %% Neumann BC
+    % -----------------------------------------------------------------
+        % column vector of prescribed traction dofs
+        BC.traction_force_dof = [];
+
+        % magnitude of prescribed tractions [N]
+        BC.traction_force_dof_value = [];
+
+        % NOTE: this is slower than prescribing tractions at dofs
+        % column vector of prescribed traction nodes 
+        BC.traction_force_node = Mesh.right_nodes;  
+
+        % prescribed traction [t1x t1y;t2x t2y;...] [N]
+        BC.traction_force_value = 1e8;
+              
+        % Make the vector into an anonymous function in time
+        BC.traction_force_value = @(t) BC.traction_force_value*t; 
+    
+        % NOTE: point loads at any of the element nodes can also be 
+        % added as a traction.
+
+        % magnitude of distributed body force [N/m] [bx;by]
+            % 1D: [N/m], 2D: [N/m2]
+        	% NOTE: if no body force, use '@(x)[]'
+         	% NOTE: anonymous functions is defined with respect to the 
+            %      variable x,  which is a vector [x(1) x(2)] = [x y]
+        BC.b = @(x,t)[];    
+
+%% Initial Conditions
+        BC.IC = zeros(Mesh.nsd*Mesh.nn,1);
+        
+%% Computation controls
+
+        % quadrature order
+        Control.qo = 2;
+
+        % Calculation of values for discontinuous variables 
+        % (i.e. stress/strain)
+        % 'none': calculated at each node for each element separately; 
+        %           no output in vtk
+        % 'nodal': averaged at each node for all elements attached to 
+        %           the node; output as nodal values in vtk
+        % 'center': calculated at the center of each element; output as 
+        %           single value for each element in vtk
+        % 'L2projection': Least squares projection of stress and strain,
+        %           output as nodal values
+        Control.stress_calc = 'L2projection';
+
+        % penalty parameter for solution of static problem with 
+        % LinearSolver3
+        Control.beta = 10^10;
+        
+        % parallel inversion
+        % Use parallel processing to invert the matrix.
+        % Usually more efficient at 2e5 dofs
+        Control.parallel = 1;
+
+        % method used for solving linear problem:
+        % 'LinearSolver1': Partitioning
+        % 'LinearSolver2': Zeroing DOFs in stiffness matrix 
+        %                   corresponding to essential boundaries
+        % 'LinearSolver3': Penalty method
+        Control.LinearSolver = 'LinearSolver1';    
+ 
+        % time controls
+        Control.StartTime = 0;
+        Control.EndTime   = 2*pi;
+        NumberOfSteps     = 50;
+        Control.TimeStep  = (Control.EndTime - Control.StartTime)/(NumberOfSteps);
+        % save displacements and stresses at each timestep in matlab 
+        % debugging and testing purposes only, vtk files are otherwise
+        % recommended
+        Control.dSave     = 1; 
+        Control.plotAt = Mesh.nDOF; % end node
+        
+        % Newton Raphson controls
+        Control.r_tol = 1e-5; % Tolerance on residual forces
+        Control.iter_max = 50; % Maximum number of iteration in Newton Raphson algorithm
+        
+end

--- a/Config Files/NLElastic_1DBar.m
+++ b/Config Files/NLElastic_1DBar.m
@@ -289,6 +289,9 @@ function [Mesh, Material, BC, Control] = NLElastic_1DBar(config_dir, progress_on
         % debugging and testing purposes only, vtk files are otherwise
         % recommended
         Control.dSave     = 1; 
+        % Plot load vs displacement curve
+        Control.plotLoadDispl = 1;
+        % DOF to plot
         Control.plotAt = Mesh.nDOF; % end node
         
         % Newton Raphson controls

--- a/Config Files/NLElastic_2DPlate.m
+++ b/Config Files/NLElastic_2DPlate.m
@@ -297,6 +297,9 @@ function [Mesh, Material, BC, Control] = NLElastic_2DPlate(config_dir, progress_
         % debugging and testing purposes only, vtk files are otherwise
         % recommended
         Control.dSave     = 1; 
+        % Plot load vs displacement curve
+        Control.plotLoadDispl = 1;
+        % DOF to plot
         Control.plotAt = Mesh.nDOF; % dof in y at bottom right node
         
         % Newton Raphson controls

--- a/Config Files/NLElastic_2DPlate.m
+++ b/Config Files/NLElastic_2DPlate.m
@@ -230,7 +230,7 @@ function [Mesh, Material, BC, Control] = NLElastic_2DPlate(config_dir, progress_
 
         % prescribed traction [t1x t1y;t2x t2y;...] [N]
         Fnode = 1e8/(length(BC.traction_force_node) - 1);
-        BC.traction_force_value = Fnode*[ones(size(BC.traction_force_node)), zeros(size(BC.traction_force_node))];
+        BC.traction_force_value = Fnode*[zeros(size(BC.traction_force_node)), ones(size(BC.traction_force_node))];
         
         % find the nodes in the top right and bottom right corners
         toprightnode = find(Mesh.x(BC.traction_force_node,2) == max(Mesh.x(:,2)));
@@ -290,14 +290,14 @@ function [Mesh, Material, BC, Control] = NLElastic_2DPlate(config_dir, progress_
  
         % time controls
         Control.StartTime = 0;
-        Control.EndTime   = 2*pi;
+        Control.EndTime   = 1*pi;
         NumberOfSteps     = 50;
         Control.TimeStep  = (Control.EndTime - Control.StartTime)/(NumberOfSteps);
         % save displacements and stresses at each timestep in matlab 
         % debugging and testing purposes only, vtk files are otherwise
         % recommended
         Control.dSave     = 1; 
-        Control.plotAt = Mesh.nDOF-1; % dof in x at bottom right node
+        Control.plotAt = Mesh.nDOF; % dof in y at bottom right node
         
         % Newton Raphson controls
         Control.r_tol = 1e-5; % Tolerance on residual forces

--- a/Config Files/NLElastic_2DPlate.m
+++ b/Config Files/NLElastic_2DPlate.m
@@ -1,4 +1,4 @@
-function [Mesh, Material, BC, Control] = Plate_NLelastic(config_dir, progress_on)
+function [Mesh, Material, BC, Control] = NLElastic_2DPlate(config_dir, progress_on)
 %PLATENLELASTIC Mesh, material parameters, boundary conditions, 
 %and control parameters
 %   Mesh = PLATENLELASTIC() is a structure array with the
@@ -127,7 +127,7 @@ function [Mesh, Material, BC, Control] = Plate_NLelastic(config_dir, progress_on
             % size of domain [m] [Lx;Ly;Lz] 
             L = [1;1];
             % number of elements in each direction [nex; ney; nez] 
-            nex = [2;2]*10;
+            nex = [1;1];
             % element type ('Q4')
             type = 'Q4';
             
@@ -297,7 +297,7 @@ function [Mesh, Material, BC, Control] = Plate_NLelastic(config_dir, progress_on
         % debugging and testing purposes only, vtk files are otherwise
         % recommended
         Control.dSave     = 1; 
-        Control.plotAt = Mesh.nDOF - 1; % dof in x at bottom right node
+        Control.plotAt = Mesh.nDOF-1; % dof in x at bottom right node
         
         % Newton Raphson controls
         Control.r_tol = 1e-5; % Tolerance on residual forces

--- a/Config Files/Plate_NLelastic.m
+++ b/Config Files/Plate_NLelastic.m
@@ -179,7 +179,7 @@ function [Mesh, Material, BC, Control] = Plate_NLelastic(config_dir, progress_on
 
     % Properties material 1
     Material.Prop(1).E = 2e11; % Young's modulus [Pa]
-    Material.Prop(1).E1 = 1e11; % Young's modulus [Pa]
+    Material.Prop(1).E1 = 1e20; % Young's modulus [Pa]
     Material.Prop(1).nu = 0.3; % Poisson's ratio
     
     % type of material per element
@@ -229,7 +229,7 @@ function [Mesh, Material, BC, Control] = Plate_NLelastic(config_dir, progress_on
         BC.traction_force_node = Mesh.right_nodes;  
 
         % prescribed traction [t1x t1y;t2x t2y;...] [N]
-        Fnode = 1e7/(length(BC.traction_force_node) - 1);
+        Fnode = 1e8/(length(BC.traction_force_node) - 1);
         BC.traction_force_value = Fnode*[ones(size(BC.traction_force_node)), zeros(size(BC.traction_force_node))];
         
         % find the nodes in the top right and bottom right corners

--- a/Config Files/Plate_NLelastic.m
+++ b/Config Files/Plate_NLelastic.m
@@ -1,0 +1,305 @@
+function [Mesh, Material, BC, Control] = Plate_NLelastic(config_dir, progress_on)
+%PLATENLELASTIC Mesh, material parameters, boundary conditions, 
+%and control parameters
+%   Mesh = PLATENLELASTIC() is a structure array with the
+%   following fields: 
+%       .type:          the topological class of finite element; it is in 
+%                       the general form 'topology-#of nodes' ie a three 
+%                       node triangle is T3 a four node quadralateral is 
+%                       Q4 a 4 node tetrahedra is H4 a 27 node brick is 
+%                       B27 etc. Presently defined are L2, Q4, and Q9. 
+%       .nsd:           Number of spatial dimensions
+%       .ne:            Total number of elements in the mesh
+%       .nne:           Vector of number of nodes per element (size nsd x 1)
+%       .nn:            Total number of nodes 
+%       .nDOFe:         Number of DOFs per element
+%       .nDOF:          Total number of DOFs
+%       .x:             Array of nodal spatial locations for
+%                       undeformed mesh (size nn x nsd)
+%       .conn:          Array of element connectivity (size ne x nne)
+%       .eneighbours:   Array of neighbouring elements (size ne x nneighbours
+%                       in which nneighbours is 1 for 1D elements and 4
+%                       for 2D elements)
+%       .DOF:           Array of DOF indices (size nn x nsd)
+%       .nodeconn:      Array of nodal connectivity (size nn x 8)
+%                       containing the indices of elements connected to 
+%                       each node
+%       .left_nodes     Nodes on the left edge of the domain
+%       .left_dof       DOFs on the left edge of the domain
+%       .right_nodes    Nodes on the right edge of the domain
+%       .right_dof      DOFs on the right edge of the domain
+%       .xdofs          DOFs in the x-direction
+%       .ydofs          DOFs in the y-direction
+%       .zdofs          DOFs in the z-direction
+%   Two-dimensional meshes also contain the fields,
+%       .top_nodes      Nodes on the top edge of the domain
+%       .top_dof        DOFs on the top edge of the domain
+%       .top_dofx       DOFs on the top boundary in the x-direction
+%       .top_dofy       DOFs on the top boundary in the y-direction
+%       .bottom_nodes   Nodes on the bottom edge of the domain
+%       .bottom_dof     DOFs on the bottom edge of the domain
+%       .bottom_dofx    DOFs on the bottom boundary in the x-direction
+%       .bottom_dofy    DOFs on the bottom boundary in the y-direction
+%       .left_dofx      DOFs on the left boundary in the x-direction
+%       .left_dofy      DOFs on the left boundary in the y-direction
+%       .right_dofx     DOFs on the right boundary in the x-direction
+%       .right_dofy     DOFs on the right boundary in the y-direction
+%   Three-dimensional meshes also contain the fields, 
+%       .near_nodes     nodes on the nearest face of the domain
+%       .near_dof       DOFs on the nearest face of the domain
+%       .near_dofx      DOFs on the near face in the x-direction
+%       .near_dofy      DOFs on the near face in the y-direction
+%       .near_dofz      DOFs on the near face in the z-direction
+%       .far_nodes      Nodes on the farthest face of the domain
+%       .far_dof        DOFs on the farthest face of the domain
+%       .far_dofx       DOFs on the far face in the x-direction
+%       .far_dofy       DOFs on the far face in the y-direction
+%       .far_dofz       DOFs on the far face in the z-direction
+%       .left_dofz      DOFs on the left face in the z-direction
+%       .right_dofz     DOFs on the right face in the z-direction
+%       .top_dofz       DOFs on the top face in the z-direction
+%       .bottom_dofz    DOFs on the bottom face in the z-direction
+%       
+%   Mesh = PLATENLELASTIC(config_dir) defines the mesh using GMSH file 
+%   import located in the directory config_dir
+%
+%   [Mesh, Material] = PLATENLELASTIC() also returns a
+%   structure array with the following fields: 
+%       .nmp:           number of material properties
+%       .Prop:          Material properties
+%       .Prop.E:        Modulus of elasticity
+%       .Prop.nu:       Poisson's ratio
+%       .Prop.Dtype:    2D approximation ('PlaneStrain' or 'PlainStress')
+%       .Prop.t:        Material thickness
+% 
+%   [Mesh, Material, BC] = PLATENLELASTIC() also returns a structure
+%   array with the following fields: 
+%       .fix_disp_dof:              Column vector of degrees of freedom 
+%                                   with prescribed displacements
+%                                   (size nfixed x 1)
+%       .fix_disp_value             Column vector of prescribed 
+%                                   displacements (size nfixed x 1)
+%       .traction_force_dof         Column vector of degrees of freedom
+%                                   with prescribed tractions
+%       .traction_force_dof_value   Column vector of prescribed tractions
+%                                   on DOF
+%       .traction_force_node        Column vector of nodes with 
+%                                   prescribed tractions
+%       .traction_force_value       Column vector of prescribed tractions
+%                                   on nodes
+%       .b                          Anonymous function of distributed
+%                                   body force (size 1 x nsd)
+% 
+%   [Mesh, Material, BC, Control] = PLATENLELASTIC() also returns a 
+%   structure array with the following fields: 
+%       .qo:            Quadrature order
+%       .stress_calc    Calculation of values for discontinous variables
+%                       ('none', 'nodal', 'center', 'L2projection')
+%       .beta:          Penalty parameter  
+%       .LinearSolver   Method used for solving linear problem:
+%                       'LinearSolver1': Partitioning
+%                       'LinearSolver2': Zeroing DOFs in stiffness matrix 
+%                                        corresponding to essential boundaries
+%                       'LinearSolver3': Penalty method
+%   --------------------------------------------------------------------
+%   Input
+%   --------------------------------------------------------------------
+%   config_dir:     (OPTIONAL) File path for the directory where 
+%                   unstructured mesh is stored
+
+%% Mesh Properties
+    if progress_on
+        disp([num2str(toc),': Building Mesh...']);
+    end
+    
+    % Mesh formats: 
+    %   'MANUAL'- In-house structured meshing
+    % 	'GMSH'  - Import .msh file from GMSH, structured or unstructured
+    %   'EXCEL' - Import .xlsx file, structured or unstructured
+    MeshType = 'MANUAL';        
+    
+    switch MeshType
+        case 'MANUAL'
+            % location of initial node [m] [x0;y0;z0] 
+            x1 = [0;0;0];
+            % number of space dimensions 
+            nsd = 2;
+            % size of domain [m] [Lx;Ly;Lz] 
+            L = [1;1];
+            % number of elements in each direction [nex; ney; nez] 
+            nex = [2;2]*10;
+            % element type ('Q4')
+            type = 'Q4';
+            
+            Mesh = BuildMesh_structured(nsd, x1, L, nex, type, progress_on);
+        case 'GMSH'
+            % Allows input of files from GMSH
+            % Note: the only currently supported .msh file formatting is
+            % Version 2 ASCII
+            % Ctrl + e to export the mesh, specify extension .msh, specify
+            % format Version 2 ASCII
+            meshFileName = 'Unstructured_sample.msh';
+            % number of space dimensions 
+            nsd = 2;
+            % Optional 5th input in case Q8 with reduced integration is desired
+            Q8_reduced = 'Q8'; %Do not consider this input if a case different than Q8 with reduced integration is desired
+            
+            Mesh = BuildMesh_GMSH(meshFileName, nsd, config_dir, progress_on);            
+%             Mesh = BuildMesh_GMSH(meshFileName, nsd, config_dir, progress_on,Q8_reduced);  
+        case 'EXCEL'
+            meshFileName = 'CricularInclusion.xlsx';
+            % number of space dimensions
+            nsd = 2;
+            
+            Mesh = BuildMesh_EXCEL(meshFileName, nsd, config_dir, progress_on);
+    end    
+    
+%% Material Properties (Solid)
+
+    % NOTES-------------------------------------------------------------
+                                
+        % NOTE: anonymous functions are defined with respect to the variable x,
+        % which is a vector [x(1) x(2) x(3)] = [x y z]
+
+        % NOTE: Material properties must be continuous along an element, 
+        % otherwise, quadrature order must be increased significantly
+        
+        % NOTE: Number of material properties can be more than one. Properties
+        % for different materials are saved in Material.Prop.
+        % For example, Young's modulus and Poisson's ratio of ith material will be saved in
+        % Material.Prop(i).E and Material.Prop(i).nu, respectively.
+        
+    % Specify stiffness matrix and stress/strain calculation files
+    Material.ConstitutiveLawFile = 'getD_NLelastic';
+    Material.StiffnessMatrixFile = 'getK_NLelastic';
+    Material.StressStrainFile = 'getStrain_NLelastic';
+    
+    % number of material properties
+    Material.nmp = 1;
+
+    % Properties material 1
+    Material.Prop(1).E = 2e11; % Young's modulus [Pa]
+    Material.Prop(1).E1 = 1e11; % Young's modulus [Pa]
+    Material.Prop(1).nu = 0.3; % Poisson's ratio
+    
+    % type of material per element
+    Mesh.MatList = zeros(Mesh.ne, 1, 'int8');
+    
+    % assign material type to elements
+    Mesh.MatList(:) = 1;
+
+    % Constitutive law: 'PlaneStrain' or 'PlaneStress' 
+    Material.Dtype = 'PlaneStress'; 
+
+    % Thickness (set as default to 1)
+    % 1D: [m2], 2D: [m]
+    Material.t = @(x) 1;
+
+    % Alternatively, import a material file
+    % Material = Material_shale();
+
+%% Boundary Conditions
+    % {TIPS}------------------------------------------------------------
+        % TIP selecting edges:
+        % bottom_nodes = find(Mesh.x(:,2)==0); 
+        % top_nodes = find(Mesh.x(:,2)==2);
+        % left_nodes = find(Mesh.x(:,1)==0);
+        % right_nodes = find(Mesh.x(:,1)==4);
+        % bottom_dof = [bottom_nodes*2 - 1; bottom_nodes*2];
+        % top_dof = [top_nodes*2 - 1;top_nodes*2];
+
+    % Dirichlet boundary conditions (essential)
+    % -----------------------------------------------------------------
+        % column vector of prescribed displacement dof  
+        BC.fix_disp_dof = Mesh.left_dof;
+
+        % prescribed displacement for each dof [u1; u2; ...] [m]
+        BC.fix_disp_value = @(t) zeros(length(BC.fix_disp_dof),1);  
+
+    %% Neumann BC
+    % -----------------------------------------------------------------
+        % column vector of prescribed traction dofs
+        BC.traction_force_dof = [];
+
+        % magnitude of prescribed tractions [N]
+        BC.traction_force_dof_value = [];
+
+        % NOTE: this is slower than prescribing tractions at dofs
+        % column vector of prescribed traction nodes 
+        BC.traction_force_node = Mesh.right_nodes;  
+
+        % prescribed traction [t1x t1y;t2x t2y;...] [N]
+        Fnode = 1e7/(length(BC.traction_force_node) - 1);
+        BC.traction_force_value = Fnode*[ones(size(BC.traction_force_node)), zeros(size(BC.traction_force_node))];
+        
+        % find the nodes in the top right and bottom right corners
+        toprightnode = find(Mesh.x(BC.traction_force_node,2) == max(Mesh.x(:,2)));
+        botrightnode = find(Mesh.x(BC.traction_force_node,2) == min(Mesh.x(:,2)));
+        
+        BC.traction_force_value(toprightnode,1) = BC.traction_force_value(toprightnode,1)/2;
+        BC.traction_force_value(botrightnode,1) = BC.traction_force_value(botrightnode,1)/2;
+        
+        % Make the vector into an anonymous function in time
+        BC.traction_force_value = @(t) BC.traction_force_value*t; 
+    
+        % NOTE: point loads at any of the element nodes can also be 
+        % added as a traction.
+
+        % magnitude of distributed body force [N/m] [bx;by]
+            % 1D: [N/m], 2D: [N/m2]
+        	% NOTE: if no body force, use '@(x)[]'
+         	% NOTE: anonymous functions is defined with respect to the 
+            %      variable x,  which is a vector [x(1) x(2)] = [x y]
+        BC.b = @(x,t)[];    
+
+%% Initial Conditions
+        BC.IC = zeros(Mesh.nsd*Mesh.nn,1);
+        
+%% Computation controls
+
+        % quadrature order
+        Control.qo = 2;
+
+        % Calculation of values for discontinuous variables 
+        % (i.e. stress/strain)
+        % 'none': calculated at each node for each element separately; 
+        %           no output in vtk
+        % 'nodal': averaged at each node for all elements attached to 
+        %           the node; output as nodal values in vtk
+        % 'center': calculated at the center of each element; output as 
+        %           single value for each element in vtk
+        % 'L2projection': Least squares projection of stress and strain,
+        %           output as nodal values
+        Control.stress_calc = 'L2projection';
+
+        % penalty parameter for solution of static problem with 
+        % LinearSolver3
+        Control.beta = 10^10;
+        
+        % parallel inversion
+        % Use parallel processing to invert the matrix.
+        % Usually more efficient at 2e5 dofs
+        Control.parallel = 1;
+
+        % method used for solving linear problem:
+        % 'LinearSolver1': Partitioning
+        % 'LinearSolver2': Zeroing DOFs in stiffness matrix 
+        %                   corresponding to essential boundaries
+        % 'LinearSolver3': Penalty method
+        Control.LinearSolver = 'LinearSolver1';    
+ 
+        % time controls
+        Control.StartTime = 0;
+        Control.EndTime   = 2*pi;
+        NumberOfSteps     = 50;
+        Control.TimeStep  = (Control.EndTime - Control.StartTime)/(NumberOfSteps);
+        % save displacements and stresses at each timestep in matlab 
+        % debugging and testing purposes only, vtk files are otherwise
+        % recommended
+        Control.dSave     = 0; 
+        
+        % Newton Raphson controls
+        Control.r_tol = 1e-5; % Tolerance on residual forces
+        Control.iter_max = 50; % Maximum number of iteration in Newton Raphson algorithm
+        
+end

--- a/Config Files/Plate_NLelastic.m
+++ b/Config Files/Plate_NLelastic.m
@@ -296,7 +296,8 @@ function [Mesh, Material, BC, Control] = Plate_NLelastic(config_dir, progress_on
         % save displacements and stresses at each timestep in matlab 
         % debugging and testing purposes only, vtk files are otherwise
         % recommended
-        Control.dSave     = 0; 
+        Control.dSave     = 1; 
+        Control.plotAt = Mesh.nDOF - 1; % dof in x at bottom right node
         
         % Newton Raphson controls
         Control.r_tol = 1e-5; % Tolerance on residual forces

--- a/Functions/Assembly/getK.m
+++ b/Functions/Assembly/getK.m
@@ -32,9 +32,6 @@ function K = getK(Mesh, Quad, Material)
 
 % Acknowledgements: Chris Ladubec
 
-% initialize D matrix file pointer
-[~,DMatrix_functn] = fileparts(Material.ConstitutiveLawFile);
-
 % initialize stiffness matrix
 vec_size = Mesh.ne*(Mesh.nne * Mesh.nsd)^2; % vector size (solid dofs)
 row = zeros(vec_size, 1);                   % vector of row indices
@@ -59,7 +56,7 @@ for e = 1:Mesh.ne
         
     %% Constitutive matrix
         nMat = Mesh.MatList(e); % element material type
-        D = feval(DMatrix_functn, Material.Prop(nMat).E, Material.Prop(nMat).nu, Mesh.nsd, Material.Dtype);
+        D = getD(nMat, Material, Mesh);
         
     %% Shape functions and derivatives in parent coordinates
         W = Quad.W;

--- a/Functions/Assembly/getK_NLelastic.m
+++ b/Functions/Assembly/getK_NLelastic.m
@@ -1,0 +1,162 @@
+function [K, R, Fint] = getK_NLelastic(Mesh, Quad, Material, Fext, ~, ~, d, ~, ~, ~, ~)
+%GETK_NLELASTIC Stiffness matrix for iterative non linear elastic case
+%   [K, R, Fint] = GETK_NLELASTIC(Mesh, Quad, Material) returns the 
+%   stiffness matrix K, the residual vector R, and the internal force 
+%   vector for the iterative solver where the problem uses a non linear 
+%   elastic material
+%   
+%   Template file for other tangent matrix files 
+%   --------------------------------------------------------------------
+%   Accepted Inputs (in order)
+%   --------------------------------------------------------------------
+%   getK_NLelastic(Mesh, Quad, Material, Klin, M, d, dnm1, dnm2, stress, strain, dt, dtnm1)
+%   Mesh:       Structure array with the following fields, may be updated
+%               with new fields
+%               .ne:    Total number of elements in the mesh
+%               .nne:   Vector of number of nodes per element (size nsd x 1)
+%               .nsd:   Number of spatial dimensions
+%               .conn:  Array of element connectivity (size ne x nne)
+%               .x:     Array of nodal spatial locations for
+%                       undeformed mesh (size nn x nsd)
+%               .DOF:   Array of DOF indices (size nn x nsd)
+%               .nDOFe: Number of DOFs per element
+%               .nDOF:  Total number of DOFs
+%  
+%   Quad:       Structure array with the following fields, may be updated
+%               with new fields
+%               .W:      Vector of quadrature weights (size nq x 1)      
+%               .nq:     Number of quadrature points 
+%               .Nq:     Cell array (size nq x 1) with shape functions  
+%                        evaluated at each quadrature point
+%               .dNdxiq: Cell array (size nq x 1) with derivative of shape 
+%                        functions w.r.t. parent coordinates evaluated at 
+%                        each quadrature point
+% 
+%   Material:   Structure array with the following fields, may be updated
+%               with new fields
+%               .t:         Material thickness
+%
+%   Fext:       External force vector at timestep n
+%   Klin:       Linear elastic stiffness matrix
+%   M:          Mass matrix
+%   d:          unconverged degree of freedom vector at current timestep n and iteration
+%   dnm1:       converged degree of freedom vector at timestep n-1
+%   dnm2:       converged degree of freedom vector at timestep n-2
+%   dt:         timestep size between timesteps n-1 and n
+%   dtnm1:      timestep size between timesteps n-2 and n-1
+
+% initialize D matrix file pointer
+[~,DMatrix_functn] = fileparts(Material.ConstitutiveLawFile);
+
+% initialize stiffness matrix
+vec_size = Mesh.ne*(Mesh.nne * Mesh.nsd)^2; % vector size (solid dofs)
+row = zeros(vec_size, 1);                   % vector of row indices
+col = zeros(vec_size, 1);                   % vector of column indices
+Kvec = zeros(vec_size, 1);                  % vectorized stiffness matrix
+
+count = 1;                                  % DOF counter
+
+% for each element, compute element stiffness matrix and add to global
+for e = 1:Mesh.ne
+
+    %% Element variables
+        % nodal ids of the element's nodes
+        enodes = Mesh.conn(e,:);    
+        % global coordinates of the element's nodes
+        xI = Mesh.x(enodes,:);  
+        % DOFs of element nodes
+        dofE = Mesh.DOF(enodes,:);
+        dofE = reshape(dofE',Mesh.nDOFe,[]);
+        % number of degrees of freedom
+        ndofE = numel(dofE);
+        % displacements of the element's nodes
+        de = d(dofE);
+        % element material type
+        nMat = Mesh.MatList(e); 
+
+    %% Shape functions and derivatives in parent coordinates
+        W = Quad.W;
+        nq = Quad.nq;
+
+    %% Assemble stiffness matrix
+    
+        % length of element. used to check that quadrature points and weights 
+        % are correct. A = Sum Wi*Ji
+        A = 0;
+
+        % initialize element stiffness matrix
+        Ke = zeros(ndofE, ndofE); 
+
+        % loop through all quadrature points
+        for q = 1:nq     
+
+            % Shape functions and derivatives in parent coordinates
+            N = Quad.Nq{q};
+            dNdxi = Quad.dNdxiq{q};
+
+            % quadrature point in physical coordinates
+            Xi = xI'*N;
+
+            % Jacobian of the transformation between parent and global 
+            % coordinates
+            Je = dNdxi'*xI;
+           
+            % determinant of the Jacobian
+            dJe = det(Je);
+            if dJe < 0
+               error('Element %d has a negative Jacobian.', e)
+            end
+
+            % derivative of shape function in physical coordinates 
+            % (tensor form)
+            dNdxi = dNdxi';
+            B = Je\dNdxi;
+
+            % convert B matrix to Voigt form
+            Bv = getBv(B', Mesh.nsd);
+            
+            % for 2D, volume integral includes the thickness
+            switch Mesh.nsd 
+                case 1
+                    L = Material.t(Xi);
+                case 2
+                    L = Material.t(Xi);
+                case 3
+                    L = 1;                
+            end
+
+            % compute strains in quadrature point
+            strain_e = Bv'*de;
+
+            % Compute constitutive matrix
+            D = feval(DMatrix_functn, nMat, Material, Mesh, strain_e);
+
+            % Calculate local stiffness matrix
+            Ke = Ke + W(q)*Bv*D*Bv'*L*dJe;
+
+            % quadrature debug tool
+            A = A + W(q)*dJe; 
+        end
+   
+    %% Forming the vectorized stiffness matrix
+        count = count + ndofE^2;
+        Ke = reshape(Ke, [ndofE^2, 1]);
+        rowmatrix = dofE*ones(1,ndofE);        
+        rowe = reshape(rowmatrix,[ndofE^2, 1]);
+        cole = reshape(rowmatrix',[ndofE^2, 1]);
+        
+        Kvec(count-ndofE^2:count-1) = Ke;
+        row(count-ndofE^2:count-1) = rowe;
+        col(count-ndofE^2:count-1) = cole;
+end
+
+% sparse stiffness matrix
+K = sparse(row, col, Kvec, Mesh.nDOF, Mesh.nDOF);
+
+% internal forces
+Fint = K*d;
+
+% residual
+R = Fext - Fint;
+
+end

--- a/Functions/Assembly/getStrain.m
+++ b/Functions/Assembly/getStrain.m
@@ -1,4 +1,4 @@
-function [strain, stress] = getStrain(d, Mesh, Material, calc_type, Quad)
+function [strain, stress] = getStrain(d, Mesh, Material, calc_type, Quad, ~)
 %GETSTRAIN Evaluate stress and strain
 %   [strain, stress] = GETSTRAIN(d, Mesh, Material) returns two matrices of 
 %   strains and stresses computed at the center of each element. The 
@@ -56,9 +56,6 @@ function [strain, stress] = getStrain(d, Mesh, Material, calc_type, Quad)
 %       	         each quadrature point
 %       	.Nv:     Cell array (size nq x 1) with shape functions 
 %       	         evaluated at each quadrature point in Voigt form
-
-% initialize D matrix file pointer
-[~,DMatrix_functn] = fileparts(Material.ConstitutiveLawFile);
 
 if nargin < 4
     calc_type = 'center';

--- a/Functions/Assembly/getStrain.m
+++ b/Functions/Assembly/getStrain.m
@@ -57,6 +57,9 @@ function [strain, stress] = getStrain(d, Mesh, Material, calc_type, Quad)
 %       	.Nv:     Cell array (size nq x 1) with shape functions 
 %       	         evaluated at each quadrature point in Voigt form
 
+% initialize D matrix file pointer
+[~,DMatrix_functn] = fileparts(Material.ConstitutiveLawFile);
+
 if nargin < 4
     calc_type = 'center';
 end
@@ -110,7 +113,7 @@ else
                 de = d(dofE);
             %% Constitutive matrix
                 nMat = Mesh.MatList(e); % element material type
-                D = getD(Material.Prop(nMat).E, Material.Prop(nMat).nu, Mesh.nsd, Material.Dtype);
+                D = getD(nMat, Material, Mesh);
         
         switch calc_type
             case 'center'

--- a/Functions/Assembly/getStrain_NLelastic.m
+++ b/Functions/Assembly/getStrain_NLelastic.m
@@ -59,6 +59,8 @@ function [strain, stress] = getStrain_NLelastic(d, Mesh, Material, calc_type, Qu
 %       	         each quadrature point
 %       	.Nv:     Cell array (size nq x 1) with shape functions
 %       	         evaluated at each quadrature point in Voigt form
+%
+%   dnm1:       d at time step n-1 
 
 % initialize D matrix file pointer
 [~,DMatrix_functn] = fileparts(Material.ConstitutiveLawFile);
@@ -114,6 +116,8 @@ else
         dofE = reshape(dofE',Mesh.nDOFe,[]);
         % local displacement vector
         de = d(dofE);
+        % local displacement vector from step n-1
+        de_nm1 = dnm1(dofE);
         % element material type
         nMat = Mesh.MatList(e); 
         

--- a/Functions/Assembly/getStrain_NLelastic.m
+++ b/Functions/Assembly/getStrain_NLelastic.m
@@ -128,6 +128,11 @@ else
                 Je = dNdxi'*xI;
                 B = Je\(dNdxi');
                 Bv = getBv(B', Mesh.nsd);
+                % strain from step n-1
+                strain_nm1 = Bv'*de_nm1;
+                % calculate constitutive matrix
+                D = feval(DMatrix_functn, nMat, Material, Mesh, strain_nm1);
+                % strain and stress at current step
                 strain(:, e) = Bv'*de;
                 stress(:, e) = D*strain(:, e);
             case 'nodal'
@@ -155,7 +160,14 @@ else
                     
                     % convert B matrix to Voigt form
                     Bv = getBv(B', Mesh.nsd);
+
+                    % strain from step n-1
+                    strain_nm1 = Bv'*de_nm1;
                     
+                    % calculate constitutive matrix
+                    D = feval(DMatrix_functn, nMat, Material, Mesh, strain_nm1);
+                    
+                    % strain and stress at current step
                     % strain_e = [strainx_n1  strainx_n2...;
                     %strainy_n1  strainy_n2...;
                     %strainxy_n1 strainxy_n2...];
@@ -171,9 +183,6 @@ else
                 A_e = zeros(Mesh.nne, Mesh.nne);
                 de_e = zeros(Mesh.nne,dim);    % column vector of strains exx
                 ds_e = zeros(Mesh.nne,dim);    % column vector of stresses sxx
-                
-                % strain in element from previous step
-                strain_e_old = strain_old(:,e);
                 
                 % loop through all quadrature points
                 for q = 1:Quad.nq
@@ -200,8 +209,11 @@ else
                     % calculate strain at quadrature point
                     strain_q = Bv'*de;
                     
+                    % strain from step n-1
+                    strain_nm1 = Bv'*de_nm1;
+                    
                     % calculate constitutive matrix
-                    D = feval(DMatrix_functn, nMat, Material, Mesh, strain_e_old);
+                    D = feval(DMatrix_functn, nMat, Material, Mesh, strain_nm1);
                     
                     % calculate stress at quadrature point
                     stress_q = D*strain_q;

--- a/Functions/Assembly/getStrain_NLelastic.m
+++ b/Functions/Assembly/getStrain_NLelastic.m
@@ -1,0 +1,253 @@
+function [strain, stress] = getStrain_NLelastic(d, Mesh, Material, calc_type, Quad, strain_old)
+%GETSTRAIN Evaluate stress and strain
+%   [strain, stress] = GETSTRAIN(d, Mesh, Material) returns two matrices of
+%   strains and stresses computed at the center of each element. The
+%   matrices are of size dim x ne, in which dim = 1 for 1D elements, 3 for
+%   2D elements, and 6 for 3D elements.
+%
+%   [strain, stress] = GETSTRAIN(d, Mesh, Material, 'none') does not
+%   compute the stresses or strains
+%
+%   [strain, stress] = GETSTRAIN(d, Mesh, Material, 'nodal') returns
+%   matrices of nodal-averaged strains (size dim x nn).
+%
+%   [strain, stress] = GETSTRAIN(d, Mesh, Material, 'center') returns
+%   matrices of strains computed at the center of each element
+%   (size dim x ne).
+%
+%   [strain, stress] = GETSTRAIN(d, Mesh, Material, 'L2projection') returns
+%   matrices of L2-projected stresses at the nodes (size dim x nn).
+%
+%   --------------------------------------------------------------------
+%   Input
+%   --------------------------------------------------------------------
+%   d:          Vector of displacements at each DOF (size ndof x 1 in
+%               which ndof is the number of degrees of freedom)
+%
+%   Mesh:       Structure array with the following fields,
+%               .nsd:   Number of spatial dimensions
+%               .ne:    Total number of elements in the mesh
+%               .nn:    Total number of nodes
+%               .nne:   Vector of number of nodes per element (size nsd x 1)
+%               .type:  the toplogical class of finite element; it is in
+%                       the general form 'topology-#of nodes' ie a three
+%                       node triangle is T3 a four node quadralateral is
+%                       Q4 a 4 node tetrahedra is H4 a 27 node brick is
+%                       B27 etc. Presently defined are L2, Q4, and Q9.
+%               .nDOFe: Number of DOFs per element
+%               .conn:  Array of element connectivity (size ne x nne)
+%               .x:     Array of nodal spatial locations for
+%                       undeformed mesh (size nn x nsd)
+%               .DOF:   Array of DOF indices (size nn x nsd)
+%
+%   Material:   Structure array with the following fields,
+%               .E:     Modulus of elasticity
+%               .nu:    Poisson's ratio
+%               .Dtype: 2D approximation ('PlaneStrain' or 'PlainStress')
+%
+% 	Quad: 	Structure array with following fields,
+%       	.nq:     Number of quadrature points
+%       	.W:      Vector of quadrature weights (size nq x 1)
+%       	.Q:      Vector of quadrature points	(size nq x nsd)
+%       	.Nq:     Cell array (size nq x 1) with shape functions
+%       	         evaluated at each quadrature point
+%       	.dNdxiq: Cell array (size nq x 1) with derivative of shape
+%       	         functions w.r.t. parent coordinates evaluated at
+%       	         each quadrature point
+%       	.Nv:     Cell array (size nq x 1) with shape functions
+%       	         evaluated at each quadrature point in Voigt form
+
+% initialize D matrix file pointer
+[~,DMatrix_functn] = fileparts(Material.ConstitutiveLawFile);
+
+if nargin < 4
+    calc_type = 'center';
+end
+
+% Specify dimension of the strain/stress matrix
+switch Mesh.nsd
+    case 1
+        dim = 1;
+    case 2
+        dim = 3;
+    case 3
+        dim = 6;
+end
+
+if strcmp(calc_type, 'none')
+    strain = zeros(dim, Mesh.ne);
+    stress = zeros(dim, Mesh.ne);
+else
+    % Specify type of strain/stress matrix/cell
+    switch calc_type
+        case 'nodal'
+            strain = zeros(dim, Mesh.nn);
+            stress = zeros(dim, Mesh.nn);
+            count = zeros(dim, Mesh.nn);
+        case 'center'
+            strain = zeros(dim, Mesh.ne);
+            stress = zeros(dim, Mesh.ne);
+        case 'L2projection'
+            vec_size = Mesh.ne*Mesh.nne;
+            A = zeros(vec_size,1); % matrix of integrals of shape functions - vectorized
+            row = zeros(vec_size,1); % vector of row indices
+            col = zeros(vec_size,1); % vector of column indices
+            count = 1;
+            
+            be = zeros(Mesh.nn, dim); % column vectors of strains
+            bs = zeros(Mesh.nn, dim); % column vectors of stresses
+    end
+    
+    % Loop through all elements
+    for e = 1:Mesh.ne
+        
+        %% Element variables
+        % nodal ids of the element's nodes
+        enodes = Mesh.conn(e,:);
+        % global coordinates of the element's nodes
+        xI = Mesh.x(enodes,:);
+        % DOFs of element nodes
+        dofE = Mesh.DOF(enodes,:);
+        dofE = reshape(dofE',Mesh.nDOFe,[]);
+        % local displacement vector
+        de = d(dofE);
+        % element material type
+        nMat = Mesh.MatList(e); 
+        
+        switch calc_type
+            case 'center'
+                xi = zeros(1,Mesh.nsd);
+                [~, dNdxi] = lagrange_basis(Mesh.type, xi, Mesh.nsd);
+                Je = dNdxi'*xI;
+                B = Je\(dNdxi');
+                Bv = getBv(B', Mesh.nsd);
+                strain(:, e) = Bv'*de;
+                stress(:, e) = D*strain(:, e);
+            case 'nodal'
+                % initialize strain element
+                strain_e = zeros(dim, Mesh.nne);
+                stress_e = zeros(dim, Mesh.nne);
+                
+                % loop through all nodes and calculate nodal strains/stresses
+                for n = 1:Mesh.nne
+                    
+                    % node point in parent coordinate
+                    xi = getXI(n, Mesh.type);
+                    
+                    % Shape function and derivatives in parent coordinates
+                    [~, dNdxi] = lagrange_basis(Mesh.type, xi, Mesh.nsd);
+                    
+                    % Jacobian of the transformation between parent and global
+                    % coordinates
+                    Je = dNdxi'*xI;
+                    
+                    % derivative of shape function in physical coordinates
+                    % (tensor form)
+                    dNdxi = dNdxi';
+                    B = Je\dNdxi;
+                    
+                    % convert B matrix to Voigt form
+                    Bv = getBv(B', Mesh.nsd);
+                    
+                    % strain_e = [strainx_n1  strainx_n2...;
+                    %strainy_n1  strainy_n2...;
+                    %strainxy_n1 strainxy_n2...];
+                    strain_e(:,n) = Bv'*de;
+                    stress_e(:,n) = D*strain_e(:,n);
+                end
+                % Add to global strains
+                strain(:,enodes) = strain(:,enodes) + strain_e;
+                stress(:,enodes) = stress(:,enodes) + stress_e;
+                count(:,enodes) = count(:,enodes) + 1;
+            case 'L2projection'
+                % initialize elemental matrices and vectors
+                A_e = zeros(Mesh.nne, Mesh.nne);
+                de_e = zeros(Mesh.nne,dim);    % column vector of strains exx
+                ds_e = zeros(Mesh.nne,dim);    % column vector of stresses sxx
+                
+                % strain in element from previous step
+                strain_e_old = strain_old(:,e);
+                
+                % loop through all quadrature points
+                for q = 1:Quad.nq
+                    
+                    % Shape functions and derivatives in parent coordinates
+                    N = Quad.Nq{q}';
+                    dNdxi = Quad.dNdxiq{q};
+                    
+                    % Jacobian of the transformation between parent and global
+                    % coordinates
+                    Je = dNdxi'*xI;
+                    
+                    % determinant of the Jacobian
+                    dJe = det(Je);
+                    
+                    % derivative of shape function in physical coordinates
+                    % (tensor form)
+                    dNdxi = dNdxi';
+                    B = Je\dNdxi;
+                    
+                    % convert B matrix to Voigt form
+                    Bv = getBv(B', Mesh.nsd);
+                    
+                    % calculate strain at quadrature point
+                    strain_q = Bv'*de;
+                    
+                    % calculate constitutive matrix
+                    D = feval(DMatrix_functn, nMat, Material, Mesh, strain_e_old);
+                    
+                    % calculate stress at quadrature point
+                    stress_q = D*strain_q;
+                    
+                    % Element level integral of L2-projections
+                    A_e = A_e + N'*N*Quad.W(q)*dJe;
+                    
+                    for i = 1:dim
+                        de_e(:,i) = de_e(:,i) +  N'*Quad.W(q)*dJe*strain_q(i);
+                        ds_e(:,i) = ds_e(:,i) +  N'*Quad.W(q)*dJe*stress_q(i);
+                    end
+                end
+                
+                % Add to global matrices and vectors
+                % Form the vectorized A matrix
+                nAe = Mesh.nne^2; % number of entries in A matrix
+                count = count + nAe;
+                A_e = reshape(A_e, [nAe,1]);
+                rowmatrix = enodes'*ones(1,Mesh.nne);
+                row_e = reshape(rowmatrix, [nAe,1]);
+                col_e = reshape(rowmatrix',[nAe,1]);
+                
+                A(count-nAe:count-1) = A_e;
+                row(count-nAe:count-1) = row_e;
+                col(count-nAe:count-1) = col_e;
+                
+                % Add element vectors to global vectors
+                be(enodes,:) = be(enodes,:) + de_e;
+                bs(enodes,:) = bs(enodes,:) + ds_e;
+        end
+    end
+    
+    
+    switch calc_type
+        case 'nodal'
+            % For nodal strains, divide by count to get the average
+            strain = strain./count;
+            stress = stress./count;
+        case 'L2projection'
+            % For L2 projection, solve the system of equations and assemble the
+            % nodal matrix of stresses and strains
+            A = sparse(row, col, A, Mesh.nn, Mesh.nn);
+            eL2 = zeros(size(be));
+            sL2 = zeros(size(bs));
+            
+            for i = 1:dim
+                eL2(:,i) = A\be(:,i);
+                sL2(:,i) = A\bs(:,i);
+            end
+            
+            strain = eL2';
+            stress = sL2';
+    end
+end
+
+end

--- a/Functions/Assembly/getStrain_NLelastic.m
+++ b/Functions/Assembly/getStrain_NLelastic.m
@@ -1,22 +1,25 @@
-function [strain, stress] = getStrain_NLelastic(d, Mesh, Material, calc_type, Quad, strain_old)
+function [strain, stress] = getStrain_NLelastic(d, Mesh, Material, calc_type, Quad, dnm1)
 %GETSTRAIN Evaluate stress and strain
-%   [strain, stress] = GETSTRAIN(d, Mesh, Material) returns two matrices of
-%   strains and stresses computed at the center of each element. The
-%   matrices are of size dim x ne, in which dim = 1 for 1D elements, 3 for
-%   2D elements, and 6 for 3D elements.
+%   [strain, stress] = GETSTRAIN_NLELASTIC(d, Mesh, Material) returns two 
+%   matrices of strains and stresses computed at the center of each element. 
+%   The matrices are of size dim x ne, in which dim = 1 for 1D elements, 3 
+%   for 2D elements, and 6 for 3D elements.
+%   
+%   The non linear elastic material is defined by the law:
+%   E = E0 + E1*I1^2
 %
-%   [strain, stress] = GETSTRAIN(d, Mesh, Material, 'none') does not
-%   compute the stresses or strains
+%   [strain, stress] = GETSTRAIN_NLELASTIC(d, Mesh, Material, 'none') does 
+%   not compute the stresses or strains
 %
-%   [strain, stress] = GETSTRAIN(d, Mesh, Material, 'nodal') returns
-%   matrices of nodal-averaged strains (size dim x nn).
+%   [strain, stress] = GETSTRAIN_NLELASTIC(d, Mesh, Material, 'nodal') 
+%   returns matrices of nodal-averaged strains (size dim x nn).
 %
-%   [strain, stress] = GETSTRAIN(d, Mesh, Material, 'center') returns
-%   matrices of strains computed at the center of each element
+%   [strain, stress] = GETSTRAIN_NLELASTIC(d, Mesh, Material, 'center') 
+%   returns matrices of strains computed at the center of each element
 %   (size dim x ne).
 %
-%   [strain, stress] = GETSTRAIN(d, Mesh, Material, 'L2projection') returns
-%   matrices of L2-projected stresses at the nodes (size dim x nn).
+%   [strain, stress] = GETSTRAIN_NLELASTIC(d, Mesh, Material, 'L2projection') 
+%   returns matrices of L2-projected stresses at the nodes (size dim x nn).
 %
 %   --------------------------------------------------------------------
 %   Input

--- a/Functions/Constitutive Law/getD.m
+++ b/Functions/Constitutive Law/getD.m
@@ -1,6 +1,6 @@
-function D = getD(E, nu, nsd, Dtype)
+function D = getD(nMat, Material, Mesh)
 %GETD Elasticity tensor
-%   D = GETD(E, nu, nsd) is the elasticity tensor for a problem of 
+%   D = GETD(nMat, Material, Mesh) is the elasticity tensor for a problem of 
 %   spatial dimension, nsd, Young's modulus, E, and Poisson's ratio, nu. 
 %   For a 1D problem, a scalar is returned. For a 2D problem, a 3x3 
 %   matrix is returned, and for a 3D problem, a 6x6 matrix is returned. 
@@ -8,15 +8,25 @@ function D = getD(E, nu, nsd, Dtype)
 %   --------------------------------------------------------------------
 %   Input
 %   --------------------------------------------------------------------
-%   E:      Modulus of elasticity
-%   nu:     Poisson's ratio
-%   nsd:    Number of spatial dimensions
+%   nMat:       Material type
+%   Mesh:       Structure array with the following fields, may be updated
+%               with new fields
+%               .nsd:   Number of spatial dimensions
+%   Material:   Structure array with the following fields, may be updated
+%               with new fields
+%               .Dtype: constitutive law for two-dimensional elasticity
+%               .E: Modulus of elasticity
+%               .nu: Poisson's ratio
+%   --------------------------------------------------------------------
 
-switch nsd
+E = Material.Prop(nMat).E;
+nu = Material.Prop(nMat).nu;
+
+switch Mesh.nsd
     case 1
         D = E;
     case 2                 
-        switch Dtype
+        switch Material.Dtype
             case 'PlaneStrain'
                 D  = E/((1+nu)*(1-2*nu))*[1-nu  nu   0     ;
                                           nu    1-nu 0     ;

--- a/Functions/Constitutive Law/getD_NLelastic.m
+++ b/Functions/Constitutive Law/getD_NLelastic.m
@@ -54,7 +54,7 @@ switch Mesh.nsd
         % strain invariant
         I1 = (strain_e(1,1)+strain_e(2,1)+ strain_e(3,1))^2;
         % elasticity modulus
-        E = E0 - E1*I1^2;
+        E = E0 + E1*I1^2;
         % constitutive matrix
         D = E/(1+nu)/(1-2*nu)*[1-nu nu nu 0 0 0;
                                 nu 1-nu nu 0 0 0;

--- a/Functions/Constitutive Law/getD_NLelastic.m
+++ b/Functions/Constitutive Law/getD_NLelastic.m
@@ -1,0 +1,67 @@
+function D = getD_NLelastic(nMat, Material, Mesh, strain_e)
+%GETD Elasticity tensor
+%   D = GETD_NLelastic(E, nu, nsd) is the elasticity tensor for a problem 
+%   in which the constitutive law is a non linear elastic relation given by
+%   E = E0 - E1*I1^2
+% 
+%   --------------------------------------------------------------------
+%   Input
+%   --------------------------------------------------------------------
+%   nMat:       Material type
+%   Mesh:       Structure array with the following fields, may be updated
+%               with new fields
+%               .nsd:   Number of spatial dimensions
+%   Material:   Structure array with the following fields, may be updated
+%               with new fields
+%               .Dtype: constitutive law for two-dimensional elasticity
+%               .E: Modulus of elasticity
+%               .nu: Poisson's ratio
+%   strain_e:   element strains
+%   --------------------------------------------------------------------
+
+E0 = Material.Prop(nMat).E;
+E1 = Material.Prop(nMat).E1;
+nu = Material.Prop(nMat).nu;
+
+% constitutive matrix
+switch Mesh.nsd
+    case 1
+        % strain invariant
+        I1 = strain_e(1,1)^2;
+        % elasticity modulus
+        E = E0 - E1*I1^2;
+        % constitutive matrix
+        D = E;
+    case 2    
+        % strain invariant
+        I1 = (strain_e(1,1)+strain_e(2,1))^2;
+        % elasticity modulus
+        E = E0 - E1*I1^2;
+        % constitutive matrix
+        switch Material.Dtype
+            case 'PlaneStrain'
+                D  = E/((1+nu)*(1-2*nu))*[1-nu  nu   0     ;
+                                          nu    1-nu 0     ;
+                                          0     0    0.5-nu];
+            case 'PlaneStress'
+                D  = E/(1-nu^2)*[1  nu 0       ;
+                                 nu 1  0       ;
+                                 0  0  (1-nu)/2];
+            otherwise
+                error('Material.Dtype is not correctly defined.')
+        end
+    case 3
+        % strain invariant
+        I1 = (strain_e(1,1)+strain_e(2,1)+ strain_e(3,1))^2;
+        % elasticity modulus
+        E = E0 - E1*I1^2;
+        % constitutive matrix
+        D = E/(1+nu)/(1-2*nu)*[1-nu nu nu 0 0 0;
+                                nu 1-nu nu 0 0 0;
+                                nu nu 1-nu 0 0 0;
+                                0 0 0 (1-2*nu)/2 0 0;
+                                0 0 0 0 (1-2*nu)/2 0;
+                                0 0 0 0 0 (1-2*nu)/2];
+end
+
+end

--- a/Functions/Constitutive Law/getD_NLelastic.m
+++ b/Functions/Constitutive Law/getD_NLelastic.m
@@ -2,7 +2,7 @@ function D = getD_NLelastic(nMat, Material, Mesh, strain_e)
 %GETD Elasticity tensor
 %   D = GETD_NLelastic(E, nu, nsd) is the elasticity tensor for a problem 
 %   in which the constitutive law is a non linear elastic relation given by
-%   E = E0 - E1*I1^2
+%   E = E0 + E1*I1^2
 % 
 %   --------------------------------------------------------------------
 %   Input

--- a/Functions/Constitutive Law/getD_NLelastic.m
+++ b/Functions/Constitutive Law/getD_NLelastic.m
@@ -36,7 +36,7 @@ switch Mesh.nsd
         % strain invariant
         I1 = (strain_e(1,1)+strain_e(2,1))^2;
         % elasticity modulus
-        E = E0 - E1*I1^2;
+        E = E0 + E1*I1^2;
         % constitutive matrix
         switch Material.Dtype
             case 'PlaneStrain'

--- a/Functions/Constitutive Law/getD_NLelastic.m
+++ b/Functions/Constitutive Law/getD_NLelastic.m
@@ -29,7 +29,7 @@ switch Mesh.nsd
         % strain invariant
         I1 = strain_e(1,1)^2;
         % elasticity modulus
-        E = E0 - E1*I1^2;
+        E = E0 + E1*I1^2;
         % constitutive matrix
         D = E;
     case 2    

--- a/Functions/Main/main_nonlinear.m
+++ b/Functions/Main/main_nonlinear.m
@@ -189,27 +189,26 @@ end
         if progress_on
             fprintf(['\n', num2str(toc),': Timestep %d converged with %d iterations ...\n'], step_count, iter);
         end
-      
-
 
     % Strain calculation
         if progress_on
             disp([num2str(toc),': Post-Processing...']);
         end
-        [strain_nm1, stress_nm1] = feval(stressstrainfile_name, d, Mesh, Material, Control.stress_calc, Quad, strain);   
+        [strain, stress] = feval(stressstrainfile_name, d, Mesh, Material, Control.stress_calc, Quad, dnm1);   
 
 
     % Write to vtk
         Fext(BC.fixed) = Fint(BC.fixed);   % Set external forces as equal to reaction forces at fixed dof for output
         
         if plot2vtk
-            write2vtk_quasistatic(config_name, vtk_dir, Mesh, Control, BC.fixed, d, strain_nm1, stress_nm1, ...
+            write2vtk_quasistatic(config_name, vtk_dir, Mesh, Control, BC.fixed, d, strain, stress, ...
                             Fint, Fext, step_count);
         end
         
         if Control.dSave
            dSave(:,step_count+1) = d; 
-           sSave(:,:,step_count + 1) = stress_nm1;
+           sSave(:,:,step_count + 1) = stress;
+           loadSave(:,step_count+1) = Fext;
         end
         
      
@@ -230,13 +229,12 @@ end
      
      % Update vectors from previous timesteps
      dnm2 = dnm1;                       % d vector from timestep n-2
-     dnm1 = d;                          % d vector from timestep n-1
-     strain = strain_nm1;               % strain matrix from time n-1     
-     
+     dnm1 = d;                          % d vector from timestep n-1     
      
  end
      if Control.dSave
          d = dSave; 
+         plotLoadVsDispl(loadSave, dSave, Control);
      end
  
      if progress_on

--- a/Functions/Main/main_nonlinear.m
+++ b/Functions/Main/main_nonlinear.m
@@ -75,7 +75,7 @@
     
     % Export initial conditions
         % Strain
-        [strain, stress] = feval(stressstrainfile_name, d0, Mesh, Material, Control.stress_calc, Quad);   
+        [strain, stress] = getStrain(d0, Mesh, Material, Control.stress_calc, Quad);
 
     % Internal force vectors
         Fint = K*d0;

--- a/Functions/Main/main_nonlinear.m
+++ b/Functions/Main/main_nonlinear.m
@@ -196,20 +196,20 @@ end
         if progress_on
             disp([num2str(toc),': Post-Processing...']);
         end
-        [strain, stress] = feval(stressstrainfile_name, d, Mesh, Material, Control.stress_calc, Quad);   
+        [strain_nm1, stress_nm1] = feval(stressstrainfile_name, d, Mesh, Material, Control.stress_calc, Quad, strain);   
 
 
     % Write to vtk
         Fext(BC.fixed) = Fint(BC.fixed);   % Set external forces as equal to reaction forces at fixed dof for output
         
         if plot2vtk
-            write2vtk_quasistatic(config_name, vtk_dir, Mesh, Control, BC.fixed, d, strain, stress, ...
+            write2vtk_quasistatic(config_name, vtk_dir, Mesh, Control, BC.fixed, d, strain_nm1, stress_nm1, ...
                             Fint, Fext, step_count);
         end
         
         if Control.dSave
            dSave(:,step_count+1) = d; 
-           sSave(:,:,step_count + 1) = stress;
+           sSave(:,:,step_count + 1) = stress_nm1;
         end
         
      
@@ -231,7 +231,7 @@ end
      % Update vectors from previous timesteps
      dnm2 = dnm1;                       % d vector from timestep n-2
      dnm1 = d;                          % d vector from timestep n-1
-          
+     strain = strain_nm1;               % strain matrix from time n-1     
      
      
  end

--- a/Functions/Main/main_nonlinear.m
+++ b/Functions/Main/main_nonlinear.m
@@ -94,9 +94,10 @@
 if Control.dSave
     n_timesteps = ceil((Control.EndTime - Control.StartTime)/dt);
     dSave = zeros(length(d0),n_timesteps+1);
-    dSave(:,1) = d0;                                   % Save displacements
+    dSave(:,1) = d0;                                % Save displacements
     sSave = zeros(3,Mesh.nn, n_timesteps+1);        % Save stresses
     sSave(:,:,1) = stress;
+    loadSave = zeros(length(d0),n_timesteps+1);     % Save applied load
 end
         
  %% Solve the time-dependent nonlinear problem

--- a/Functions/Main/main_nonlinear.m
+++ b/Functions/Main/main_nonlinear.m
@@ -243,6 +243,9 @@ end
  end
      if Control.dSave
          d = dSave; 
+     end
+     
+     if Control.plotLoadDispl
          plotLoadVsDispl(loadSave, dSave, Control);
      end
  

--- a/Functions/Main/main_nonlinear.m
+++ b/Functions/Main/main_nonlinear.m
@@ -95,7 +95,15 @@ if Control.dSave
     n_timesteps = ceil((Control.EndTime - Control.StartTime)/dt);
     dSave = zeros(length(d0),n_timesteps+1);
     dSave(:,1) = d0;                                % Save displacements
-    sSave = zeros(3,Mesh.nn, n_timesteps+1);        % Save stresses
+    switch Mesh.nsd
+        case 1
+            dim = 1;
+        case 2
+            dim = 3;
+        case 3
+            dim = 6;
+    end
+    sSave = zeros(dim,Mesh.nn, n_timesteps+1);        % Save stresses
     sSave(:,:,1) = stress;
     loadSave = zeros(length(d0),n_timesteps+1);     % Save applied load
 end

--- a/Functions/Main/setDefaults.m
+++ b/Functions/Main/setDefaults.m
@@ -226,6 +226,10 @@ function [Mesh, Material, BC, Control] = setDefaults(Mesh, Material, BC, Control
         Control.dSave = 0;
     end
     
+    if ~isfield(Control, 'plotLoadDispl')
+        Control.plotLoadDispl = 0;
+    end
+    
 %% Output
 
 war_message = sprintf('%s %s %s %s %s', war_message, war_mesh, war_mat, war_BC, war_control);

--- a/Functions/Post-processing/plotLoadVsDispl.m
+++ b/Functions/Post-processing/plotLoadVsDispl.m
@@ -1,0 +1,25 @@
+function plotLoadVsDispl(F, d, Control)
+% PLOTLOADVSDISPL Plots displacement vs load curve
+%   --------------------------------------------------------------------
+%   Input
+%   --------------------------------------------------------------------
+%   F:  Matrix of externally applied loads (size nDOF x nsteps)
+%   d: Matrix of displacements (size nDOF x nsteps)
+%   Control: Structure array with the following field
+%           .plotAt: selected DOF to plot curve (defined in Config File) 
+
+% DOF to plot
+plotAt = Control.plotAt;
+d_plot = d(plotAt, :);
+F_plot = F(plotAt, :);
+
+% plot
+figure;
+plot(d_plot, F_plot, 'k-o', 'LineWidth', 1.5);
+hold on
+title('Load vs. Displacement curve');
+xlabel('Displacement (m)');
+ylabel('Load (N)');
+hold off
+
+end


### PR DESCRIPTION
## What?
Add a nonlinear elastic constitutive model.
## Why?
To expand the functionalities of the code in terms of material models.
## How?
By using the recently introduced function pointers, the user can define the formats of the tangent stiffness matrix, constitutive matrix, and strain computation to simulate a nonlinear elastic behavior.
## Testing?
Plate_NLelastic (Config Files)
## Anything Else?
For the first step of the first iteration, the stiffness matrix, constitutive matrix, and strain matrix are computed as in the linear elastic case by default. For the following iterations, the function pointers defined by the users redirect the code to the correspondent functions. In addition, now the strain from the previous step needs to be stored so that the constitutive matrix of the current step can be computed.