### PR TITLE
Aitken relaxation

### DIFF
--- a/Config Files/MasterConfigFile.m
+++ b/Config Files/MasterConfigFile.m
@@ -333,5 +333,19 @@ function [Mesh, Material, BC, Control] = MasterConfigFile(config_dir, progress_o
         Control.r_tol = 1e-5; % Tolerance on residual forces
         Control.iter_max = 50; % Maximum number of iteration in Newton Raphson algorithm
         
+        % Aitken Relaxation
+        % Turn on Aitken Relxation (off by default if not specified)
+        Control.aitkenON    = 1;          
+        % Min and max relaxation parameters
+        Control.aitkenRange = [0.01,10];    
+        % Allow negative aitken relaxation (turn off by default, but may be
+        % useful in very stiff problems).
+        Control.aitkenNeg   = 0;            
+        % Optional - specify the degrees of freedom to calculate the
+        % relaxation coefficient. These DOFs should not include any fixed
+        % DOFs as they interfere with the calculation of the relaxation
+        % paramter.
+        Control.relaxDOFs   = setdiff(1:Mesh.nDOF,BC.fix_disp_dof);  
+        
         
 end

--- a/Config Files/NLElastic_2DPlate.m
+++ b/Config Files/NLElastic_2DPlate.m
@@ -177,7 +177,7 @@ function [Mesh, Material, BC, Control] = NLElastic_2DPlate(config_dir, progress_
             % size of domain [m] [Lx;Ly;Lz] 
             L = [1;1];
             % number of elements in each direction [nex; ney; nez] 
-            nex = [1;1];
+            nex = [2;2];
             % element type ('Q4')
             type = 'Q4';
             
@@ -295,8 +295,8 @@ function [Mesh, Material, BC, Control] = NLElastic_2DPlate(config_dir, progress_
  
         % time controls
         Control.StartTime = 0;
-        Control.EndTime   = 3;
-        NumberOfSteps     = 50;
+        Control.EndTime   = 150;
+        NumberOfSteps     = 0.2*Control.EndTime;
         Control.TimeStep  = (Control.EndTime - Control.StartTime)/(NumberOfSteps);
         % save displacements and stresses at each timestep in matlab 
         % debugging and testing purposes only, vtk files are otherwise
@@ -317,5 +317,11 @@ function [Mesh, Material, BC, Control] = NLElastic_2DPlate(config_dir, progress_
         % Newton Raphson controls
         Control.r_tol = 1e-5; % Tolerance on residual forces
         Control.iter_max = 50; % Maximum number of iteration in Newton Raphson algorithm
+        
+        % Aitken Relaxation
+        Control.aitkenON    = 1;            % Turn on Aitken Relxation
+        Control.aitkenRange = [0.1,2];    % Min and max relaxation parameters
+        Control.aitkenNeg   = 0;            % Allow negative aitken relaxation
+        Control.relaxDOFs   = setdiff(1:Mesh.nDOF,BC.fix_disp_dof);  % Optional - specify the degrees of freedom to calculate the relaxation coefficient
         
 end

--- a/Functions/Main/aitkenRelax.m
+++ b/Functions/Main/aitkenRelax.m
@@ -35,7 +35,7 @@ function [sol_mp1_relaxed, res_m_nextIter, delta_m_nextIter, sol_m_NextIter] = .
 
 
 % Handle input.
-if nargin < 8
+if nargin < 7
     minRelax = 0.005;       maxRelax = 1;
 else
     minRelax = range(1); maxRelax = range(2);

--- a/Functions/Main/aitkenRelax.m
+++ b/Functions/Main/aitkenRelax.m
@@ -1,0 +1,77 @@
+function [sol_mp1_relaxed, res_m_nextIter, delta_m_nextIter, sol_m_NextIter] = ...
+    aitkenRelax(sol_mp1, sol_m, idxSol, res_m, delta_m, negON, range)
+% Apply Aitken delta^2 relaxation method with limited range of relaxation parameter.
+% CONTROL OPTIONS:
+% maxInitRelaxPara > 0    : Aitken's delta^2 method. delta is in [minRelax maxRelax].
+% maxInitRelaxPara < 0    : fixed relaxation parameter delta = abs(maxInitRelaxPara) is used.
+
+
+%AITKENRELAX Apply Aitken delta^2 relaxation method with limited range of relaxation parameter
+%   [sol_mp1_damped, res_m_nextCall, delta_m_nextCall, sol_m_NextCall] =
+%       aitkenRelax(sol_mp1, sol_m, idxSol, res_m, delta_m, negON, range)
+%   returns the relaxed solution at the current iteration having used the
+%   previous two iterations to improve the guess at the solution.
+% 
+%   --------------------------------------------------------------------
+%   Input
+%   --------------------------------------------------------------------
+%   sol_mp1   :     Solution at the current iteration
+%   sol_m     :     Relaxed solution from the previous iteration
+%   idxSol    :     Index of DOFs used to calculate the relaxation parameter
+%   res_m     :     Delta d from the previous iteration 
+%   delta_m   :     Relaxation parameter from previous iteration
+%   negON     :     Boolean allowing or restricting the relaxation
+%                   parameter to be negative (w<0).
+%   range     :     2x1 vector with the minimum and maximum allowed
+%                   relaxation parameters.
+% 
+%   --------------------------------------------------------------------
+%   Output
+%   --------------------------------------------------------------------
+%   sol_mp1_relaxed     :   Relaxed solution at the current iteration
+%   res_m_nextIter      :   Delta d to be used as res_m in the next iter
+%   delta_m_nextIter    :   Relaxation paramter to be used in next iter
+%   sol_m_nextIter      :   Solution to be used as sol_m in next iter
+
+
+% Handle input.
+if nargin < 8
+    minRelax = 0.005;       maxRelax = 1;
+else
+    minRelax = range(1); maxRelax = range(2);
+end
+
+% Residual of current iterate, defined as difference in iterates.
+% res_mp1 = sol_mp1(idxSol) - sol_m(idxSol);
+res_mp1 = sol_mp1 - sol_m;
+
+% Compute Aitken relaxation parameters.
+aitkenPara = delta_m * (- res_m(idxSol)' * (res_mp1(idxSol) - res_m(idxSol)) / norm(res_mp1(idxSol) - res_m(idxSol),2)^2); 
+
+
+% Constrain relaxation parameter.
+%delta = max(min(maxRelax, aitkenPara),minRelax);%*sign(aitkenPara);
+
+
+if negON
+    % If negatives aitken parameters are allowed, contrain the parameter
+    % such that it is limited to the ranges [-maxRelax to -minRelax] and
+    % [minRelax to maxRelax]
+    delsign = sign(aitkenPara);
+    if delsign == 0
+        delsign = 1;
+    end
+    delta = max(min(maxRelax, abs(aitkenPara)),minRelax)*delsign;
+else
+    delta = max(min(maxRelax,aitkenPara),minRelax);
+end
+
+sol_mp1_relaxed = (1-delta) * sol_m + delta * sol_mp1;
+
+
+% Prepare values for next call. Aitken relaxation is recursive! 
+res_m_nextIter   = res_mp1;
+delta_m_nextIter = delta;
+sol_m_NextIter   = sol_mp1_relaxed; 
+
+end

--- a/Functions/Main/aitkenRelax.m
+++ b/Functions/Main/aitkenRelax.m
@@ -44,9 +44,6 @@ aitkenPara = delta_m * (- res_m(idxSol)' * (res_mp1(idxSol) - res_m(idxSol)) / n
 
 
 % Constrain relaxation parameter.
-%delta = max(min(maxRelax, aitkenPara),minRelax);%*sign(aitkenPara);
-
-
 if negON
     % If negatives aitken parameters are allowed, contrain the parameter
     % such that it is limited to the ranges [-maxRelax to -minRelax] and

--- a/Functions/Main/aitkenRelax.m
+++ b/Functions/Main/aitkenRelax.m
@@ -1,11 +1,5 @@
 function [sol_mp1_relaxed, res_m_nextIter, delta_m_nextIter, sol_m_NextIter] = ...
     aitkenRelax(sol_mp1, sol_m, idxSol, res_m, delta_m, negON, range)
-% Apply Aitken delta^2 relaxation method with limited range of relaxation parameter.
-% CONTROL OPTIONS:
-% maxInitRelaxPara > 0    : Aitken's delta^2 method. delta is in [minRelax maxRelax].
-% maxInitRelaxPara < 0    : fixed relaxation parameter delta = abs(maxInitRelaxPara) is used.
-
-
 %AITKENRELAX Apply Aitken delta^2 relaxation method with limited range of relaxation parameter
 %   [sol_mp1_damped, res_m_nextCall, delta_m_nextCall, sol_m_NextCall] =
 %       aitkenRelax(sol_mp1, sol_m, idxSol, res_m, delta_m, negON, range)

--- a/Functions/Main/main_nonlinear.m
+++ b/Functions/Main/main_nonlinear.m
@@ -196,6 +196,8 @@ end
                 fprintf('%d',iter');
                 msg_len = numel(num2str(iter));
             end
+        
+
       
         % Compute nonlinear stiffness matrix and internal forces
             [K, ResForce, Fint] = feval(stiffnessmatrixfile_name, Mesh, Quad, Material, Fintnm1, Fext, Fextnm1, Klin, M, d_m, dt, dtnm1, C, Control.alpha); 
@@ -232,6 +234,19 @@ end
 
                 % Update displacement vector
                     d_m.d = d_m.d + Dd;
+                    
+                % Apply Aitken Relaxation
+                   if iter > 1 && Control.aitkenON
+                      [d_m.d, Dd_prevIter, aitkenCoeff, d_prevIter] = aitkenRelax(d_m.d, d_prevIter, ...
+                            Control.relaxDOFs, Dd_prevIter, aitkenCoeff, Control.aitkenNeg, Control.aitkenRange);
+                   else
+                      % Set initial relaxation parameter to 1
+                      aitkenCoeff = 1; 
+                      % Initialize d from previous iteration
+                      d_prevIter  = d_m.d;
+                      % Initialize delta d from previous iteration
+                      Dd_prevIter = Dd;
+                   end
 
                 % Update iteration number
                     iter = iter + 1;

--- a/Functions/Main/main_nonlinear.m
+++ b/Functions/Main/main_nonlinear.m
@@ -151,6 +151,9 @@ if Control.dSave
     sSave = zeros(dim,Mesh.nn, n_timesteps+1);        % Save stresses
     sSave(:,:,1) = stress;
     loadSave = zeros(length(d0),n_timesteps+1);     % Save applied load
+    
+    % Save number of iterations
+    iSave = zeros(n_timesteps,1);
 end
  
  %% Solve the time-dependent nonlinear problem
@@ -181,6 +184,9 @@ end
             msg_len = 1;
             fprintf('Newton-Raphson - Iteration:  ')
         end
+        
+    % Save residuals in a timestep
+    rSave = zeros(Control.iter_max,1);
     
     % Begin Newton-Raphson Loop
     while ~converged
@@ -205,6 +211,7 @@ end
         
         % Calculate residual
             res = norm(ResForce)/resScale;
+            rSave(iter) = res;
         
         % Check convergence
             if res < Control.r_tol
@@ -262,6 +269,7 @@ end
             dSave(:,step_count+1) = d_m.d;      %store displacement
             sSave(:,:,step_count + 1) = stress;
             loadSave(:,step_count+1) = Fext;
+            iSave(step_count) = iter;
         end
 
      % Break out of loop at end time

--- a/Functions/Main/setDefaults.m
+++ b/Functions/Main/setDefaults.m
@@ -218,6 +218,27 @@ function [Mesh, Material, BC, Control] = setDefaults(Mesh, Material, BC, Control
         Control.beta = 10^10;
     end
     
+    % Aitken Relaxation Parameters (optional)
+    if ~isfield(Control, 'aitkenON')
+        Control.aitkenON = 0; % Off by default
+    end
+    
+    if ~isfield(Control, 'aitkenRange')
+        Control.aitkenRange = [0.01,2];
+    end
+    
+    if ~isfield(Control, 'aitkenNeg')
+        Control.aitkenNeg = 0; % Off by default
+    end
+    
+    if ~isfield(Control, 'relaxDOFs')
+        Control.relaxDOFs   = setdiff(1:Mesh.nDOF,BC.fix_disp_dof);
+    else
+        % Ensure that the relaxDOFs do not contain any fixed BCs, as this
+        % interferes with the calculation of the relaxation parameter
+        Control.relaxDOFs   = setdiff(Control.relaxDOFs,BC.fix_disp_dof);
+    end
+    
     % If these variables are not defined, assume a static analysis
     if ~isfield(Control, 'StartTime')
         Control.StartTime = 0;


### PR DESCRIPTION
## What?
Add Aitken's Delta^2 Relaxation method to the Newton-Raphson iterative scheme
## Why?
To improve convergence of the Newton-Raphson iterative scheme
## How?
Refer to  
_U. Kuttler and W. A. Wall, “Fixed-Point Fluid-Structure Interaction Solvers with Dynamic Relaxation,” Computational Mechanics, Vol. 43, No. 1, 2008, pp. 61-72._ 
and
_B. Gee and R. Gracie "Comparison of fully-coupled and sequential solution methodologies for enhanced geothermal systems" Computer Methods in Applied Mechanics and Engineering, Vol. 373, 2021, pp. 113554_
for details on relaxation schemes. 
## Testing?
Comparison of a non-linear problem using model ST1. This problem does not converge at large loadsteps unless relaxation is used. Changing the range of the constraints on the relaxation parameter can improve the convergence behaviour.

![image](https://github.com/GCMLab/GCMLab-FEM/assets/71358608/9de38203-bd3f-404a-b543-52ef771610ad)
